### PR TITLE
Show mouse cursor as pointer for operator capability popover icon and styling

### DIFF
--- a/comingSoon/index.html
+++ b/comingSoon/index.html
@@ -56,7 +56,7 @@
                 <h3 id="countdown"></h3>
             </div>
             <div class="bottomleft">
-                Find the best Kubernetes Operators on OperatorHub.io
+                The registry for Kubernetes Operators
             </div>
         </div>
     <script>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,9 +3,9 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>OperatorHub.io | Find the best Kubernetes Operators on OperatorHub.io</title>
+  <title>OperatorHub.io | The registry for Kubernetes Operators</title>
   <meta id="appName" name="application-name" content="Operator Hub" />
-  <meta name="description" content="Find the best Kubernetes Operators on OperatorHub.io">
+  <meta name="description" content="The registry for Kubernetes Operators">
 
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="msapplication-TileColor" content="#ffffff">

--- a/frontend/src/styles/operator-page.scss
+++ b/frontend/src/styles/operator-page.scss
@@ -108,13 +108,15 @@
 
 .oh-capability-level-popover {
   max-width: 730px;
-  height: 300px;
+  height: 330px;
   width: 730px;
   &__img {
     max-width: 700px;
+    margin: 5px 0;
   }
   &__icon {
     display: none;
+    cursor: pointer;
     @media (min-width: 915px) {
       display: inline-block;
       margin-left: 3px;

--- a/frontend/src/styles/overrides.scss
+++ b/frontend/src/styles/overrides.scss
@@ -64,3 +64,14 @@ p {
   background-color: #e0e1e2;
   border-radius: 4px;
 }
+
+.popover {
+  -webkit-box-shadow: -5px 0px 15px rgba(0,0,0,.2);
+  box-shadow: -3px 0px 15px rgba(0,0,0,.2);
+  border-radius: 4px;
+  border: 1px solid #efefef;
+
+  &.left > .arrow {
+    border-left-color: #efefef;
+  }
+}


### PR DESCRIPTION
Fix the issue that the mouse cursor is not showing as pointer when hover over Operator Capability popover help icon.

**Before:**
![popover-icon_ori](https://user-images.githubusercontent.com/5903705/53280165-09f83300-36cc-11e9-9a19-bb061f8cd017.png)

**After:**
![popover-icon_new](https://user-images.githubusercontent.com/5903705/53280167-0e245080-36cc-11e9-92ec-a0f01bb95a9f.png)

Also include some popover styling tweaks.

**Before:**
![popover_ori](https://user-images.githubusercontent.com/5903705/53280109-81799280-36cb-11e9-99be-4639713d03a0.png)

**After:**
![popover_after](https://user-images.githubusercontent.com/5903705/53280114-88a0a080-36cb-11e9-99ed-588891533d99.png)

