### PR TITLE
Minor visual changes to hub page view bar

### DIFF
--- a/frontend/src/pages/operatorHub/OperatorHub.js
+++ b/frontend/src/pages/operatorHub/OperatorHub.js
@@ -652,14 +652,7 @@ class OperatorHub extends React.Component {
       <div className="oh-hub-page__mobile-filters">
         <div className="oh-hub-page__mobile-filters__toolbar">
           <button className="oh-filter-toggle" type="button" onClick={this.toggleFiltersOpen}>
-            {filtersOpen && <Icon className="oh-filter-close" type="pf" name="close" />}
-            {!filtersOpen && (
-              <span className="oh-filter-bars">
-                <span className="icon-bar" />
-                <span className="icon-bar" />
-                <span className="icon-bar" />
-              </span>
-            )}
+            <Icon className="oh-filter-icon" type="pf" name={filtersOpen ? 'close' : 'filter'} />
             <span>Filters</span>
           </button>
         </div>
@@ -682,10 +675,10 @@ class OperatorHub extends React.Component {
       <div className="oh-hub-page__toolbar">
         <div className="oh-hub-page__toolbar__item oh-hub-page__toolbar__item-left">
           {filteredItems.length}
-          <span className="oh-hub-page__toolbar__label oh-tiny">items</span>
+          <span className="oh-hub-page__toolbar__label oh-tiny">ITEMS</span>
         </div>
         <div className="oh-hub-page__toolbar__item">
-          <span className="oh-hub-page__toolbar__label oh-tiny">VIEW:</span>
+          <span className="oh-hub-page__toolbar__label oh-tiny">VIEW</span>
           <DropdownButton
             className="oh-hub-page__toolbar__dropdown"
             title={this.getViewItem(viewType)}
@@ -701,7 +694,7 @@ class OperatorHub extends React.Component {
           </DropdownButton>
         </div>
         <div className="oh-hub-page__toolbar__item">
-          <span className="oh-hub-page__toolbar__label oh-tiny">SORT:</span>
+          <span className="oh-hub-page__toolbar__label oh-tiny">SORT</span>
           <DropdownButton
             className="oh-hub-page__toolbar__dropdown"
             title={this.getSortItem(sortType)}

--- a/frontend/src/styles/hub-page.scss
+++ b/frontend/src/styles/hub-page.scss
@@ -39,26 +39,12 @@
     padding: 0 2px 0 0;
   }
 
-  .oh-filter-close {
+  .oh-filter-icon {
     margin-right: 5px;
     font-size: 12px;
     font-weight: 700;
-    width: 17px;
   }
 
-  .oh-filter-bars {
-    display: inline-block;
-    margin-right: 5px;
-
-    .icon-bar {
-      background-color: $oh-color-text-body;
-      display: block;
-      width: 17px;
-      height: 2px;
-      border-radius: 1px;
-      margin-top:2px;
-    }
-  }
   &__filters {
     overflow-y: hidden;
     transition-property: all;


### PR DESCRIPTION
Update mobile filter button icon from bars to filter icon
Change view bar 'items' to 'ITEMS' to be consistent with 'VIEW' and 'SORT'

Before:
![image](https://user-images.githubusercontent.com/11633780/53413345-b9b5f500-3999-11e9-8145-6c9c36b7dbed.png)

After:
![image](https://user-images.githubusercontent.com/11633780/53413373-c8041100-3999-11e9-855f-e5f36f0f4560.png)


fyi @tlwu2013 