### PR TITLE
Remove extra 7px of margin-top of the logo

### DIFF
--- a/frontend/src/styles/page.scss
+++ b/frontend/src/styles/page.scss
@@ -117,7 +117,6 @@
   &__logo {
     font-family: $oh-code-font-family;
     height: 14px;
-    margin-top: 7px;
   }
 
   &__spacer {


### PR DESCRIPTION
**before:**
![before](https://user-images.githubusercontent.com/5903705/53586202-852e6e80-3b3c-11e9-8e86-c661357ba875.png)

**before (mobile):**
![before-mobile](https://user-images.githubusercontent.com/5903705/53586676-84e2a300-3b3d-11e9-81a5-acbd0e1130e7.png)

---

**after:**
![after](https://user-images.githubusercontent.com/5903705/53586218-8bbce600-3b3c-11e9-8796-29f5c5ed1b59.png)

**after (mobile):**
![after-mobile](https://user-images.githubusercontent.com/5903705/53586666-7eecc200-3b3d-11e9-9090-8e5889bcf139.png)
