### PR TITLE
Add some info & pointers to <noscript> fallback

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -36,7 +36,12 @@
 </head>
 
 <body>
-  <noscript>Enabling JavaScript is required to run this app.</noscript>
+  <noscript>
+    <h1>Enabling JavaScript is required to run this app.</h1>
+    <p>This app was built with JavaScript to provide a fast search experience.
+      The underlying data this app presents is available at <a href="https://github.com/operator-framework/community-operators">https://github.com/operator-framework/community-operators</a> (and you can contribute new operators there).</p>
+    <p>The source code for this site is available at <a href="https://github.com/operator-framework/operatorhub.io">https://github.com/operator-framework/operatorhub.io</a>.</p>
+  </noscript>
   <div id="root"></div>
   <script type="text/javascript">
     if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -91,3 +91,13 @@
     margin-left: -40px;
   }
 }
+
+noscript {
+  margin: 20px 40px;
+  h1 {
+    text-align: center;
+  }
+  p {
+    padding: 0 30px;
+  }
+}


### PR DESCRIPTION
Inspired by [a post on operator-framework mailing list](https://groups.google.com/d/msg/operator-framework/cvdo2vguJe4/_EHjWJ2xAwAJ).
Goals: add minimal info that might make people surfing without JavaScript happier:

- [x] point to underlying data on github, one could clone and browse it directly without this app.
- [x] point to this repo with source — some people only object to running proprietary JS.
- [x] sort-of replace https://www.operatorhub.io/what-is-an-operator and https://www.operatorhub.io/contribute (which also don't work without JS)  — the community-operators repo explains these
  - [x] GitHub itself is reasonably surfable without JS — not everything works but you can see the README and learn how to git clone it.
- [ ] doesn't replace https://www.operatorhub.io/about (which also doesn't work without JS), but I guess if you can't run the app you don't care ;-)

