### PR TITLE
Fix to left align table headers in markdown viewers

### DIFF
--- a/frontend/src/styles/operator-page.scss
+++ b/frontend/src/styles/operator-page.scss
@@ -60,6 +60,10 @@
       white-space: pre-wrap;
       word-break: break-all;
     }
+
+    tr > th {
+      text-align: left;
+    }
   }
 
   &__side-panel {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/11633780/55258641-d31cbc00-5239-11e9-82ce-43184fd536da.png)

After:
![image](https://user-images.githubusercontent.com/11633780/55258619-c13b1900-5239-11e9-92f3-19be9c64a983.png)
