### PR TITLE
Don't allow generate until all sections have been visited and approved

### DIFF
--- a/frontend/src/components/editor/LabelsEditor.js
+++ b/frontend/src/components/editor/LabelsEditor.js
@@ -114,7 +114,7 @@ class LabelsEditor extends React.Component {
     const { field, keyField, keyPlaceholder, valueField, valuePlaceholder, formErrors } = this.props;
     const removeLabelClass = classNames('remove-label', { disabled: this.areLabelsEmpty() });
 
-    const errors = _.get(formErrors, field, []);
+    const errors = this.isEmptyLabel(operatorLabel) ? [] : _.get(formErrors, field, []);
     const fieldErrors = _.find(errors, { key: operatorLabel[keyField], value: operatorLabel[valueField] });
 
     const keyError = _.get(fieldErrors, 'keyError');
@@ -159,8 +159,10 @@ class LabelsEditor extends React.Component {
   };
 
   render() {
-    const { title, singular, field, keyLabel, valueLabel } = this.props;
+    const { title, singular, field, keyLabel, valueLabel, formErrors } = this.props;
     const { labels } = this.state;
+    const labelsError = _.get(formErrors, field, []);
+
     return (
       <React.Fragment>
         <h3>{title}</h3>
@@ -176,6 +178,7 @@ class LabelsEditor extends React.Component {
             <span>{`Add ${singular}`}</span>
           </a>
         </div>
+        {_.isString(labelsError) && <div className="oh-operator-editor-form__error-block">{labelsError}</div>}
       </React.Fragment>
     );
   }

--- a/frontend/src/pages/OperatorEditorPage/OperatorMetadataPage.js
+++ b/frontend/src/pages/OperatorEditorPage/OperatorMetadataPage.js
@@ -58,8 +58,13 @@ class OperatorMetadataPage extends React.Component {
   }
 
   componentDidMount() {
-    const { sectionStatus } = this.props;
+    const { sectionStatus, formErrors, storeEditorFormErrors } = this.props;
+    const { workingOperator } = this.state;
+
     this.originalStatus = sectionStatus.metadata;
+    if (this.originalStatus !== EDITOR_STATUS.empty) {
+      updateStoredFormErrors(workingOperator, formErrors, METADATA_FIELDS, storeEditorFormErrors);
+    }
   }
 
   updateOperator = (value, field) => {

--- a/frontend/src/utils/operatorDescriptors.js
+++ b/frontend/src/utils/operatorDescriptors.js
@@ -238,7 +238,7 @@ const operatorFieldPlaceholders = {
 };
 
 const linksValidator = links => {
-  if (!links || _.isEmpty(links)) {
+  if (!links || _.isEmpty(links) || (links.length === 1 && !links.name && !links.url)) {
     return 'At least one external link is required.';
   }
 
@@ -368,7 +368,6 @@ const operatorFieldValidators = {
       required: true
     },
     labels: {
-      required: true,
       isObjectProps: true,
       key: {
         required: true,
@@ -388,7 +387,6 @@ const operatorFieldValidators = {
     },
     selector: {
       matchLabels: {
-        required: true,
         isObjectProps: true,
         key: {
           required: true,

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -190,11 +190,17 @@ const getFieldValueError = (operator, field) => {
   if (fieldValidator.isObjectProps) {
     const propErrors = [];
 
+    if (fieldValidator.required && _.isEmpty(value)) {
+      return 'This field is required';
+    }
+
     _.forEach(_.keys(value), key => {
-      const keyError = getValueError(key, _.get(fieldValidator, 'key'));
-      const valueError = getValueError(_.get(value, key), _.get(fieldValidator, 'value'));
-      if (keyError || valueError) {
-        propErrors.push({ key, value: _.get(value, key), keyError, valueError });
+      if (key || value[key]) {
+        const keyError = getValueError(key, _.get(fieldValidator, 'key'));
+        const valueError = getValueError(_.get(value, key), _.get(fieldValidator, 'value'));
+        if (keyError || valueError) {
+          propErrors.push({ key, value: _.get(value, key), keyError, valueError });
+        }
       }
     });
 


### PR DESCRIPTION
Adds validator on labels that are required to exist (only links)
Show errors for empty required fields when entering after the first time.