### PR TITLE
Description markdown editor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.scss text eol=lf

--- a/frontend/src/components/editor/DescriptionEditor.js
+++ b/frontend/src/components/editor/DescriptionEditor.js
@@ -5,40 +5,67 @@ import * as _ from 'lodash-es';
 import { operatorFieldDescriptions } from '../../utils/operatorDescriptors';
 import MarkdownEditor from './MarkdownEditor';
 
-const DescriptionEditor = ({ operator, onUpdate, onValidate }) => (
-  <React.Fragment>
-    <h3>Description</h3>
-    <p>{operatorFieldDescriptions.spec.description}</p>
-    <div className="oh-operator-editor-form__field-section">
-      <MarkdownEditor
-        title="Details about the managed application"
-        description="Please describe the name, features, and use case(s) for your managed application briefly, and include links to read more about it."
-        markdown={_.get(operator, 'spec.description')}
-        onChange={markdown => onUpdate(markdown, 'spec.description')}
-        onValidate={() => onValidate('spec.description')}
-      />
-      <MarkdownEditor
-        title="Details about the Operator"
-        description="Please describe the features your Operator provides to manage the application and what is it's value add."
-        markdown={operator.aboutMarkdown}
-        onChange={markdown => onUpdate(markdown, 'aboutMarkdown')}
-        onValidate={() => onValidate('aboutMarkdown')}
-      />
-      <MarkdownEditor
-        title="Details the prerequisites for enabling the Operator"
-        description="Please describe any steps a user needs to take prior to enabling this Operator (e.g. any Secrets or ConfigMaps that need to be in place upfront)."
-        markdown={operator.prerequisitesMarkdown}
-        onChange={markdown => onUpdate(markdown, 'prerequisitesMarkdown')}
-        onValidate={() => onValidate('prerequisitesMarkdown')}
-      />
-    </div>
-  </React.Fragment>
-);
+class DescriptionEditor extends React.Component {
+  description = operatorFieldDescriptions.spec.description;
+
+  render() {
+    const { operator, formErrors, onUpdate, onValidate } = this.props;
+
+    const aboutApplication = _.get(operator, 'spec.description.aboutApplication', '');
+    const aboutOperator = _.get(operator, 'spec.description.aboutOperator', '');
+    const prerequisites = _.get(operator, 'spec.description.prerequisites', '');
+
+    const aboutApplicationError = _.get(formErrors, 'spec.description.aboutApplication');
+    const aboutOperatorError = _.get(formErrors, 'spec.description.aboutOperator');
+    const prerequisitesError = _.get(formErrors, 'spec.description.prerequisites');
+
+    return (
+      <React.Fragment>
+        <h3>Description</h3>
+        <p>{this.description}</p>
+        <div className="oh-operator-editor-form__field-section">
+          <MarkdownEditor
+            title="Details about the managed application"
+            description="Please describe the name, features, and use case(s) for your managed application briefly, and include links to read more about it."
+            markdown={aboutApplication}
+            validationError={aboutApplicationError}
+            minHeadlineLevel
+            onChange={markdown => onUpdate(markdown, 'spec.description.aboutApplication')}
+            onValidate={() => onValidate('spec.description.aboutApplication')}
+          />
+          <MarkdownEditor
+            title="Details about the Operator"
+            description="Please describe the features your Operator provides to manage the application and what is it's value add."
+            markdown={aboutOperator}
+            validationError={aboutOperatorError}
+            minHeadlineLevel
+            onChange={markdown => onUpdate(markdown, 'spec.description.aboutOperator')}
+            onValidate={() => onValidate('spec.description.aboutOperator')}
+          />
+          <MarkdownEditor
+            title="Details the prerequisites for enabling the Operator"
+            description="Please describe any steps a user needs to take prior to enabling this Operator (e.g. any Secrets or ConfigMaps that need to be in place upfront)."
+            markdown={prerequisites}
+            validationError={prerequisitesError}
+            minHeadlineLevel
+            onChange={markdown => onUpdate(markdown, 'spec.description.prerequisites')}
+            onValidate={() => onValidate('spec.description.prerequisites')}
+          />
+        </div>
+      </React.Fragment>
+    );
+  }
+}
 
 DescriptionEditor.propTypes = {
   operator: PropTypes.object.isRequired,
+  formErrors: PropTypes.object,
   onUpdate: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired
+};
+
+DescriptionEditor.defaultProps = {
+  formErrors: {}
 };
 
 export default DescriptionEditor;

--- a/frontend/src/components/editor/ListObjectEditor.js
+++ b/frontend/src/components/editor/ListObjectEditor.js
@@ -69,10 +69,7 @@ class ListObjectEditor extends React.Component {
               Invalid Entries
             </span>
           )}
-          <button
-            className="oh-button oh-button-secondary"
-            onClick={() => this.editOperatorObject(operatorObject)}
-          >
+          <button className="oh-button oh-button-secondary" onClick={() => this.editOperatorObject(operatorObject)}>
             Edit
           </button>
           <a href="#" onClick={e => this.removeOperatorObject(e, operatorObject)}>

--- a/frontend/src/components/editor/MarkdownEditor.js
+++ b/frontend/src/components/editor/MarkdownEditor.js
@@ -12,6 +12,43 @@ class MarkdownEditor extends React.Component {
     initialPos: 0
   };
 
+  static mdeOptions = {
+    spellChecker: false,
+    status: false,
+    showIcons: ['code', 'table'],
+    hideIcons: ['side-by-side', 'fullscreen'],
+    previewRender: helpers.markdownConverter.makeHtml
+  };
+
+  static ToolbarWithLevel2Headline = [
+    'bold',
+    'italic',
+    {
+      name: 'heading-smaller',
+      action: editor => {
+        const cm = editor.codemirror;
+        const text = cm.getLine(cm.getCursor('start').line);
+        const currHeadingLevel = text.search(/[^#]/);
+
+        currHeadingLevel < 2 ? editor.toggleHeading2() : editor.toggleHeadingSmaller();
+      },
+      className: 'fa fa-header',
+      title: 'Smaller Heading'
+    },
+    '|',
+    'code',
+    'quote',
+    'unordered-list',
+    'ordered-list',
+    '|',
+    'link',
+    'image',
+    'table',
+    '|',
+    'preview',
+    'guide'
+  ];
+
   onMarkdownChange = value => {
     this.props.onChange(value);
   };
@@ -46,20 +83,18 @@ class MarkdownEditor extends React.Component {
   };
 
   render() {
-    const { title, description, markdown } = this.props;
+    const { title, description, markdown, validationError, minHeadlineLevel } = this.props;
     const { contentHeight } = this.state;
 
-    const mdeOptions = {
-      spellChecker: false,
-      status: false,
-      showIcons: ['code', 'table'],
-      hideIcons: ['side-by-side', 'fullscreen'],
-      previewRender: helpers.markdownConverter.makeHtml
-    };
+    const mdeConfig = MarkdownEditor.mdeOptions;
+
+    if (minHeadlineLevel) {
+      mdeConfig.toolbar = MarkdownEditor.ToolbarWithLevel2Headline;
+    }
 
     return (
       <div
-        className="oh-markdown-viewer"
+        className={`oh-markdown-viewer${validationError ? ' oh-markdown-viewer--validationError' : ''}`}
         onMouseMove={this.resizeViewer}
         onMouseUp={this.stopResize}
         onMouseLeave={this.stopResize}
@@ -75,12 +110,13 @@ class MarkdownEditor extends React.Component {
         >
           <SimpleMdeWrapper
             markdown={markdown}
-            options={mdeOptions}
+            options={mdeConfig}
             onChange={this.onMarkdownChange}
             onBlur={this.onMarkdownBlur}
           />
         </div>
         <div className="oh-markdown-viewer__resizer" onMouseDown={this.startResize} />
+        {validationError && <div className="oh-markdown-viewer__error-block">{validationError}</div>}
       </div>
     );
   }
@@ -90,14 +126,18 @@ MarkdownEditor.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   markdown: PropTypes.string,
+  validationError: PropTypes.string,
   onChange: PropTypes.func,
-  onValidate: PropTypes.func
+  onValidate: PropTypes.func,
+  minHeadlineLevel: PropTypes.bool
 };
 
 MarkdownEditor.defaultProps = {
   markdown: '',
+  validationError: null,
   onChange: helpers.noop,
-  onValidate: helpers.noop
+  onValidate: helpers.noop,
+  minHeadlineLevel: false
 };
 
 export default MarkdownEditor;

--- a/frontend/src/pages/OperatorEditorPage/OperatorMetadataPage.js
+++ b/frontend/src/pages/OperatorEditorPage/OperatorMetadataPage.js
@@ -21,7 +21,9 @@ const METADATA_FIELDS = [
   'spec.version',
   'spec.replaces',
   'spec.minKubeVersion',
-  'spec.description',
+  'spec.description.aboutApplication',
+  'spec.description.aboutOperator',
+  'spec.description.prerequisites',
   'metadata.annotations.capabilities',
   'spec.labels',
   'spec.selector.matchLabels',
@@ -273,7 +275,12 @@ class OperatorMetadataPage extends React.Component {
         {this.renderFormField('Version', 'spec.version', 'text')}
         {this.renderFormField('Replaces (optional)', 'spec.replaces', 'text')}
         {this.renderFormField('Minimum Kubernetes Version (optional)', 'spec.minKubeVersion', 'text')}
-        <DescriptionEditor operator={workingOperator} onUpdate={this.updateOperator} onValidate={this.validateField} />
+        <DescriptionEditor
+          operator={workingOperator}
+          onUpdate={this.updateOperator}
+          onValidate={this.validateField}
+          formErrors={formErrors}
+        />
         <CapabilityEditor operator={workingOperator} onUpdate={this.updateOperatorCapability} />
         <LabelsEditor
           operator={workingOperator}

--- a/frontend/src/pages/OperatorEditorPage/editorPageUtils.js
+++ b/frontend/src/pages/OperatorEditorPage/editorPageUtils.js
@@ -8,7 +8,8 @@ import {
   operatorFieldPlaceholders,
   operatorFieldValidators
 } from '../../utils/operatorDescriptors';
-import { getFieldValueError } from '../../utils/operatorUtils';
+import { getFieldValueError, getDefaultDescription } from '../../utils/operatorUtils';
+import { OPERATOR_DESCRIPTION_ABOUT_HEADER, OPERATOR_DESCRIPTION_PREREQUISITES_HEADER } from '../../utils/constants';
 
 const EDITOR_STATUS = {
   empty: 'empty',
@@ -102,22 +103,100 @@ const operatorNameFromOperator = operator => {
   return `${name}.v${version.slice(versionStart)}`;
 };
 
+const splitDescriptionIntoSections = operator => {
+  const description = _.get(operator, 'spec.description', '');
+
+  let aboutApplication = description;
+  let aboutOperator = '';
+  let prerequisites = '';
+
+  const aboutHeaderMatch = description.match(new RegExp(`^${OPERATOR_DESCRIPTION_ABOUT_HEADER}`, 'm'));
+  const prerequisitesHeaderMatch = description.match(new RegExp(`^${OPERATOR_DESCRIPTION_PREREQUISITES_HEADER}`, 'm'));
+
+  const aboutHeaderIndex = aboutHeaderMatch !== null ? aboutHeaderMatch.index : -1;
+  const prerequisitesHeaderIndex = prerequisitesHeaderMatch !== null ? prerequisitesHeaderMatch.index : -1;
+
+  // if we can identify headers, split using them
+  // at least one header must be available
+  if (aboutHeaderIndex > -1) {
+    if (prerequisitesHeaderIndex > -1) {
+      aboutOperator = description.substring(aboutHeaderIndex, prerequisitesHeaderIndex);
+      prerequisites = description.substring(prerequisitesHeaderIndex);
+    } else {
+      aboutOperator = description.substring(aboutHeaderIndex);
+    }
+
+    aboutApplication = description.substring(0, aboutHeaderIndex);
+  } else if (prerequisitesHeaderIndex > -1) {
+    aboutApplication = description.substring(0, prerequisitesHeaderIndex);
+    prerequisites = description.substring(prerequisitesHeaderIndex);
+
+    // no our headers found, trying to match using level 2 headers
+  } else {
+    // contains splitted sections and headers using capture group inbetween splitted sections
+    const segments = description.split(/^(## [^\r?\n]+)/m);
+
+    // take first 3 ## headers and populates sections
+
+    // we have at least 3 headlines
+    if (segments.length >= 7) {
+      aboutApplication = segments.slice(0, 3).join('');
+      aboutOperator = segments.slice(3, 5).join('');
+      prerequisites = segments.slice(5).join('');
+
+      // at least 2 headlines
+    } else if (segments.length >= 5) {
+      aboutApplication = segments.slice(0, 3).join('');
+      aboutOperator = segments.slice(3).join('');
+    }
+  }
+
+  _.set(operator, 'spec.description', {
+    aboutApplication,
+    aboutOperator,
+    prerequisites
+  });
+};
+
 const normalizeYamlOperator = yaml => {
   const normalizedOperator = safeLoad(yaml);
 
   const name = _.get(normalizedOperator, 'metadata.name');
+  const description = _.get(normalizedOperator, 'spec.description');
+
   if (name) {
     const versionStart = name.indexOf('.v');
     const normalizedName = name.slice(0, versionStart);
     _.set(normalizedOperator, 'metadata.name', normalizedName);
   }
+
+  if (description) {
+    splitDescriptionIntoSections(normalizedOperator);
+
+    // if no description is available provide default one
+  } else {
+    _.set(normalizedOperator, 'spec.description', getDefaultDescription());
+  }
+
   return normalizedOperator;
+};
+
+const mergeDescriptions = operator => {
+  const description = [
+    _.get(operator, 'spec.description.aboutApplication', ''),
+    _.get(operator, 'spec.description.aboutOperator', ''),
+    _.get(operator, 'spec.description.prerequisites', '')
+  ];
+
+  // add trailing line break if is missing
+  return description.reduce((aggregator, value) => aggregator + (value.endsWith('\n') ? value : `${value}\n`), '');
 };
 
 const yamlFromOperator = operator => {
   const yamlizedOperator = _.cloneDeep(operator);
 
   _.set(yamlizedOperator, 'metadata.name', operatorNameFromOperator(operator));
+  _.set(yamlizedOperator, 'spec.description', mergeDescriptions(operator));
 
   return safeDump(yamlizedOperator);
 };
@@ -128,6 +207,7 @@ export {
   renderFormError,
   EDITOR_STATUS,
   getUpdatedFormErrors,
+  mergeDescriptions,
   operatorNameFromOperator,
   normalizeYamlOperator,
   yamlFromOperator

--- a/frontend/src/styles/operator-editor-page.scss
+++ b/frontend/src/styles/operator-editor-page.scss
@@ -100,6 +100,7 @@
 
     &__status {
       .fa, .pficon {
+        margin-left: 10px;
         margin-right: 4px;
         &.fa-minus-circle {
           color: $color-pf-red;
@@ -510,8 +511,8 @@
       }
 
       &__actions {
-        .oh-operator-editor-page__section__edit-button {
-          margin-right: 10px;
+        .oh-button {
+          margin: 0 10px;
         }
       }
     }
@@ -566,7 +567,7 @@
 
   .oh-markdown-viewer__content {
     .CodeMirror, .CodeMirror-scroll {
-      min-height: initial;     
+      min-height: initial;
     }
 
     .CodeMirror {

--- a/frontend/src/styles/operator-editor-page.scss
+++ b/frontend/src/styles/operator-editor-page.scss
@@ -100,7 +100,6 @@
 
     &__status {
       .fa, .pficon {
-        margin-left: 10px;
         margin-right: 4px;
         &.fa-minus-circle {
           color: $color-pf-red;
@@ -511,8 +510,8 @@
       }
 
       &__actions {
-        .oh-button {
-          margin: 0 10px;
+        .oh-operator-editor-page__section__edit-button {
+          margin-right: 10px;
         }
       }
     }
@@ -567,7 +566,7 @@
 
   .oh-markdown-viewer__content {
     .CodeMirror, .CodeMirror-scroll {
-      min-height: initial;
+      min-height: initial;     
     }
 
     .CodeMirror {
@@ -611,6 +610,17 @@
         border-bottom: 1px solid $color-pf-black-200;
         vertical-align: top;
       }
+    }    
+  }
+
+  &--validationError{
+    .oh-markdown-viewer__content{
+      border: 1px solid $color-pf-red;
+    }
+
+    .oh-markdown-viewer__error-block {
+      margin-top: 5px;
+      color: $color-pf-red;
     }
   }
 

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,0 +1,3 @@
+export const OPERATOR_DESCRIPTION_APPLICATION_HEADER = '## About the managed application';
+export const OPERATOR_DESCRIPTION_ABOUT_HEADER = '## About this Operator';
+export const OPERATOR_DESCRIPTION_PREREQUISITES_HEADER = '## Prerequisites for enabling this Operator';

--- a/frontend/src/utils/operatorDescriptors.js
+++ b/frontend/src/utils/operatorDescriptors.js
@@ -388,6 +388,13 @@ const nameValidator = name => {
   return null;
 };
 
+const descriptionValidator = text => {
+  const errorText =
+    'Heading level 1 is discouraged in the description as it collides with the rest of the page. Please use heading level 2 or higher.';
+
+  return /(^# [^\r?\n]+)/m.test(text) ? errorText : null;
+};
+
 const operatorFieldValidators = {
   metadata: {
     name: {
@@ -415,7 +422,18 @@ const operatorFieldValidators = {
       required: true
     },
     description: {
-      required: true
+      aboutApplication: {
+        required: true,
+        validator: descriptionValidator
+      },
+      aboutOperator: {
+        required: true,
+        validator: descriptionValidator
+      },
+      prerequisites: {
+        required: true,
+        validator: descriptionValidator
+      }
     },
     version: {
       required: true,


### PR DESCRIPTION
CSV 'spec.description' is splitted into 3 separate parts in our data model and edited using 3 editors.
Merged together when yaml is created out of data model

Replaced old PR as rebase with force push was required and PR history was completely polluted

Squashed commit:

[40a0968] CSV 'spec.description' is now separated into 3 sections and edited separately
Validation is separated as well on editor level to highlight which description violates criteria
fixed linter errors

[8e2d535] normalized line ending so it workes correctly on windows