### PR TITLE
Operator courier used to migrate operators to nested structure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ echo "Frontend build successful"
 popd
 
 pushd server
+pip3 install operator-courier==2.0.3
 npm install
 ./scripts/update-operators.sh $COMMUNITY_REPO $COMMUNITY_BRANCH || exit 1
 popd

--- a/server/scripts/update-operators.sh
+++ b/server/scripts/update-operators.sh
@@ -26,6 +26,20 @@ fi
 pushd community-operators
 git fetch origin $OPERATORS_BRANCH
 git pull origin $OPERATORS_BRANCH
+
+pushd upstream-community-operators
+
+# remove if exist from previous run
+rm -r nested-structure
+
+for f in */ ; do
+    if [ -d "$f" ]; then
+        echo "$f"
+        operator-courier nest "$f" "nested-structure/$f"
+    fi
+done
+
+popd
 popd
 
 popd

--- a/server/services/loadService.js
+++ b/server/services/loadService.js
@@ -12,6 +12,10 @@ const loadOperators = callback => {
   const csvFileList = [];
   const packages = [];
 
+  /**
+   * Scan nested folders until all CSVs are found
+   * @param {string} dir
+   */
   const allCSVFilesSync = dir => {
     fs.readdirSync(dir).forEach(file => {
       const filePath = path.join(dir, file);
@@ -25,18 +29,24 @@ const loadOperators = callback => {
 
   allCSVFilesSync(operatorsFrameworkDirectory);
 
+  /**
+   * Build operators array
+   */
   const operators = _.reduce(
     csvFileList,
     (parsedOperators, { filePath, dir }) => {
       try {
         const operator = yaml.safeLoad(fs.readFileSync(filePath));
-        const packageFile = fs.readdirSync(dir).filter(fn => fn.endsWith('.package.yaml'));
+        const packageRootFolder = path.join(dir, '..');
+        const packageFile = fs.readdirSync(packageRootFolder).filter(fn => fn.endsWith('.package.yaml'));
+
+        // add package info into operator
         if (packageFile.length === 1) {
-          const packageInfo = yaml.safeLoad(fs.readFileSync(path.join(dir, packageFile[0])));
+          const packageInfo = yaml.safeLoad(fs.readFileSync(path.join(packageRootFolder, packageFile[0])));
           if (!_.find(packages, { packageName: packageInfo.packageName })) {
             packages.push(packageInfo);
           }
-          operator.packageInfo = yaml.safeLoad(fs.readFileSync(path.join(dir, packageFile[0])));
+          operator.packageInfo = packageInfo;
         }
         parsedOperators.push(operator);
       } catch (e) {
@@ -49,6 +59,8 @@ const loadOperators = callback => {
   );
 
   const normalizedOperators = normalizeOperators(operators);
+  // based on package default version find previous versions of operators
+  // so we know which versions belongs to the package
   const normalizedPackages = normalizePackages(packages, normalizedOperators);
 
   persistentStore.setPackages(normalizedPackages, packagesErr => {

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -8,7 +8,7 @@ const keysDirectory = process.env.KEYDIR || '';
 const mockMode = process.env.MOCK === 'true';
 
 const operatorsDirectory =
-  process.env.OPERATORS_DIR === undefined ? 'upstream-community-operators' : process.env.OPERATORS_DIR;
+  process.env.OPERATORS_DIR === undefined ? 'upstream-community-operators/nested-structure' : process.env.OPERATORS_DIR;
 
 const constants = {
   serverPort,

--- a/server/utils/operatorUtils.js
+++ b/server/utils/operatorUtils.js
@@ -1,5 +1,9 @@
 const _ = require('lodash');
 
+/**
+ * Converts version into string as "100000.100000.100000" (for version 0.0.0)
+ * @param {string} version
+ */
 const normalizeVersion = version =>
   version
     .split('.')
@@ -16,6 +20,10 @@ const normalizeVersion = version =>
 
 const validCapabilityStrings = ['Basic Install', 'Seamless Upgrades', 'Full Lifecycle', 'Deep Insights', 'Auto Pilot'];
 
+/**
+ * Convert capability level into one of known
+ * @param {string} capability
+ */
 const normalizeCapabilityLevel = capability => {
   if (validCapabilityStrings.includes(capability)) {
     return capability;
@@ -38,6 +46,13 @@ const getExampleYAML = (kind, operator) => {
   return null;
 };
 
+/**
+ * Recursively adds operator name and version into package channel
+ * Checks on operator for property stating which version current operator replaces
+ * @param {*} packageChannel
+ * @param {*} currentOperator
+ * @param {*} operators
+ */
 const addReplacedOperators = (packageChannel, currentOperator, operators) => {
   const replacedOperatorName = _.get(currentOperator, 'replaces');
   if (!replacedOperatorName) {
@@ -51,6 +66,11 @@ const addReplacedOperators = (packageChannel, currentOperator, operators) => {
   }
 };
 
+/**
+ * Convert package informations into internal format
+ * @param {*} operatorPackage
+ * @param {*} operators
+ */
 const getPackageChannels = (operatorPackage, operators) => {
   const { channels } = operatorPackage;
 
@@ -79,6 +99,19 @@ const getPackageChannels = (operatorPackage, operators) => {
   return _.compact(packageChannels);
 };
 
+/**
+ * @typedef PackageChannel
+ * @property {string} PackageChannel.name
+ * @property {string} PackageChannel.version
+ */
+
+/**
+ * Extracts default channel for package
+ * @param {*} operatorPackage
+ * @param {*} channels
+ * @param {*} operators
+ * @returns {PackageChannel}
+ */
 const getDefaultChannel = (operatorPackage, channels, operators) => {
   // if we have a set default channel use it
   const defaultChannelName = _.get(operatorPackage, 'defaultChannel');
@@ -166,6 +199,21 @@ const normalizeOperator = operator => {
 
 const normalizeOperators = operators => _.map(operators, operator => normalizeOperator(operator));
 
+/**
+ * @typedef Package
+ * @property {string} Package.id
+ * @property {string} Package.name
+ * @property {*[]} Package.channels
+ * @property {string} Package.defaultChannel name of the default channel
+ * @property {string} Package.defaultOperatorId id of the default channel
+ */
+
+/**
+ * Converts package into internal format
+ * @param {*} operatorPackage
+ * @param {*} operators
+ * @returns {Package}
+ */
 const normalizePackage = (operatorPackage, operators) => {
   const channels = getPackageChannels(operatorPackage, operators);
   const defaultChannel = getDefaultChannel(operatorPackage, channels, operators);


### PR DESCRIPTION
Loaded nested operators into database in same format as with flat structure

After update operator-courier create in operators new folder "nested-structure" and outputs nested structure there.
If new folder is not created operators folders contains mixed flat and nested structure what could cause troubles, therefore this is safe approach until entire repo is migrated and we remove this step.