### PR TITLE
Install modal produce install path without version

### DIFF
--- a/frontend/src/components/InstallModal.js
+++ b/frontend/src/components/InstallModal.js
@@ -29,10 +29,19 @@ class InstallModal extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    const { operator } = this.props;
+    const { operator, history } = this.props;
+    const path = history.location.pathname.split('/');
+
+    let channelName;
+    const operatorId = _.get(operator, 'id');
+
+    if (path.length === 4) {
+      [channelName] = path.slice(2);
+    }
 
     if (operator !== prevProps.operator) {
-      const installPath = `install/${_.get(operator, 'channel')}/${_.get(operator, 'name')}.yaml`;
+      const installPath = `install/${channelName ? `${_.get(operator, 'channel')}/` : ''}${operatorId}.yaml`;
+
       this.setState({
         installCommand: `kubectl create -f ${window.location.origin}/${installPath}`
       });

--- a/server/utils/operatorUtils.js
+++ b/server/utils/operatorUtils.js
@@ -128,7 +128,21 @@ const normalizeCRDs = operator => {
   return _.map(customResourceDefinitions, crd => normalizeCRD(crd, operator));
 };
 
-const generateIdFromVersionedName = name => name.slice(0, name.indexOf('.'));
+/**
+ * Returns operator name without version as operator Id
+ * Cover case when there is no version in name
+ * @param {string} name
+ */
+const generateIdFromVersionedName = name => {
+  let operatorId = name;
+
+  // use method only if there is dot
+  if (operatorId.indexOf('.') > -1) {
+    operatorId = operatorId.slice(0, name.indexOf('.'));
+  }
+
+  return operatorId;
+};
 
 const isGlobalOperator = installModes => _.some(installModes, { type: 'AllNamespaces', supported: true });
 


### PR DESCRIPTION
Removed backward compatibility on server as path with version is invalid, we support only latest operator version installation (+1 squashed commits)
Server created install yaml for lastest operator in channel or in default channel
Picked method impl "getOperatorsById" from other branch