### PR TITLE
Compare uploaded manifest against default operator

### DIFF
--- a/frontend/src/components/editor/ManifestUploader.js
+++ b/frontend/src/components/editor/ManifestUploader.js
@@ -90,9 +90,9 @@ class ManifestUploader extends React.Component {
     // field changed when either its value changed
     // or uploaded operator was same as default values
     !_.isEqual(_.get(operator, fieldName), _.get(mergedOperator, fieldName)) ||
-    (_.isEqual(_.get(defaultOperator, fieldName), _.get(uploadedOperator, fieldName)) &&
-      // do not consider updated if value is empty - no real change was doen
-      !_.isEmpty(_.get(defaultOperator, fieldName)));
+    // do not consider updated if value is empty - no real change was doen
+    (!_.isEmpty(_.get(defaultOperator, fieldName)) &&
+      _.isEqual(_.get(defaultOperator, fieldName), _.get(uploadedOperator, fieldName)));
 
   doUploadUrl = (contents, url) => {
     const { uploads } = this.state;

--- a/frontend/src/components/editor/ManifestUploader.js
+++ b/frontend/src/components/editor/ManifestUploader.js
@@ -90,7 +90,9 @@ class ManifestUploader extends React.Component {
     // field changed when either its value changed
     // or uploaded operator was same as default values
     !_.isEqual(_.get(operator, fieldName), _.get(mergedOperator, fieldName)) ||
-    _.isEqual(_.get(defaultOperator, fieldName), _.get(uploadedOperator, fieldName));
+    (_.isEqual(_.get(defaultOperator, fieldName), _.get(uploadedOperator, fieldName)) &&
+      // do not consider updated if value is empty - no real change was doen
+      !_.isEmpty(_.get(defaultOperator, fieldName)));
 
   doUploadUrl = (contents, url) => {
     const { uploads } = this.state;


### PR DESCRIPTION
After manifest upload its checked as well against default operator values and section is marked for review if uploaded value did not change but was same as default