### PR TITLE
Changed operator links to use package name instead of operator name

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -43,8 +43,9 @@ class App extends React.Component {
     return (
       <React.Fragment>
         <Switch>
+          <Route path="/operator/:packageName/:channel/:operatorId" component={OperatorPage} />
           <Route path="/operator/:channel/:operatorId" component={OperatorPage} />
-          <Route path="/operator/:operatorId" component={OperatorPage} />
+          <Route path="/operator/:packageName" component={OperatorPage} />
           <Route path="/preview" component={OperatorPreviewPage} />
           <Route path="/bundle/metadata" component={OperatorMetadataPage} />
           <Route path="/bundle/owned-crds/:crd" component={OperatorOwnedCRDEditPage} />

--- a/frontend/src/components/modals/InstallModal.js
+++ b/frontend/src/components/modals/InstallModal.js
@@ -34,15 +34,21 @@ class InstallModal extends React.Component {
     const { operator, history } = this.props;
     const path = history.location.pathname.split('/');
 
-    let channelName;
-    const operatorId = _.get(operator, 'id');
-
-    if (path.length === 4) {
-      [channelName] = path.slice(2);
-    }
-
     if (operator !== prevProps.operator) {
-      const installPath = `install/${channelName ? `${_.get(operator, 'channel')}/` : ''}${operatorId}.yaml`;
+      let installPath;
+
+      // ["", "operator", packageName] - default path for latest operator in default channel
+      // ["", "operator", channelName, operatorName] - legacy path
+      // ["", "operator", packageName, channelName, operatorName] - full path (version / channel selected)
+
+      if (path.length > 3) {
+        // eslint-disable-next-line prefer-destructuring
+        const channelName = path.length === 5 ? path[3] : path[2];
+
+        installPath = `install/${channelName}/${operator.packageName}.yaml`;
+      } else {
+        installPath = `install/${operator.packageName}.yaml`;
+      }
 
       this.setState({
         installCommand: `kubectl create -f ${window.location.origin}/${installPath}`

--- a/frontend/src/pages/operatorHub/OperatorHub.js
+++ b/frontend/src/pages/operatorHub/OperatorHub.js
@@ -519,7 +519,7 @@ class OperatorHub extends React.Component {
 
   openDetails = (event, operator) => {
     event.preventDefault();
-    this.props.history.push(`/operator/${operator.id}`);
+    this.props.history.push(`/operator/${operator.packageName}`);
   };
 
   updateViewType = viewType => {
@@ -686,7 +686,7 @@ class OperatorHub extends React.Component {
           <OperatorTile
             operator={item}
             key={item.name}
-            href={`${window.location.origin}/operator/${item.id}`}
+            href={`${window.location.origin}/operator/${item.packageName}`}
             onClick={e => this.openDetails(e, item)}
           />
         ))}

--- a/frontend/src/pages/operatorPage/OperatorPage.js
+++ b/frontend/src/pages/operatorPage/OperatorPage.js
@@ -43,9 +43,10 @@ class OperatorPage extends React.Component {
 
   refresh() {
     const channel = _.get(this.props.match, 'params.channel');
+    const packageName = _.get(this.props.match, 'params.packageName');
     const operatorName = _.get(this.props.match, 'params.operatorId');
 
-    this.props.fetchOperator(operatorName, channel);
+    this.props.fetchOperator(operatorName, packageName, channel);
   }
 
   onHome = e => {
@@ -72,14 +73,14 @@ class OperatorPage extends React.Component {
     const { operator } = this.props;
 
     if (channel.name !== operator.channel) {
-      this.props.history.push(`/operator/${channel.name}/${channel.currentCSV}`);
+      this.props.history.push(`/operator/${operator.packageName}/${channel.name}/${channel.currentCSV}`);
     }
   };
 
   updateVersion = version => {
     const { operator } = this.props;
 
-    this.props.history.push(`/operator/${operator.channel}/${version.name}`);
+    this.props.history.push(`/operator/${operator.packageName}/${operator.channel}/${version.name}`);
   };
 
   showInstall = e => {
@@ -227,7 +228,7 @@ OperatorPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  fetchOperator: (name, channel) => dispatch(fetchOperator(name, channel)),
+  fetchOperator: (name, packageName, channel) => dispatch(fetchOperator(name, packageName, channel)),
   storeKeywordSearch: keywordSearch =>
     dispatch({
       type: reduxConstants.SET_KEYWORD_SEARCH,

--- a/frontend/src/services/operatorsService.js
+++ b/frontend/src/services/operatorsService.js
@@ -11,7 +11,7 @@ const serverURL = `http://${serverHost}:${serverPort}`;
 const allOperatorsRequest = process.env.DEV_MODE ? `${serverURL}/api/operators` : `/api/operators`;
 const operatorRequest = process.env.DEV_MODE ? `${serverURL}/api/operator` : `/api/operator`;
 
-const fetchOperator = (operatorName, channel) => dispatch => {
+const fetchOperator = (operatorName, packageName, channel) => dispatch => {
   dispatch({
     type: helpers.PENDING_ACTION(reduxConstants.GET_OPERATORS)
   });
@@ -25,7 +25,13 @@ const fetchOperator = (operatorName, channel) => dispatch => {
     return;
   }
 
-  const config = { params: { name: operatorName, channel } };
+  const config = {
+    params: {
+      name: operatorName,
+      channel,
+      packageName
+    }
+  };
   axios
     .get(operatorRequest, config)
     .then(response => {

--- a/server/services/loadService.js
+++ b/server/services/loadService.js
@@ -36,7 +36,7 @@ const loadOperators = callback => {
           if (!_.find(packages, { packageName: packageInfo.packageName })) {
             packages.push(packageInfo);
           }
-          operator.packageInfo = yaml.safeLoad(fs.readFileSync(path.join(dir, packageFile[0])));
+          operator.packageInfo = packageInfo;
         }
         parsedOperators.push(operator);
       } catch (e) {
@@ -55,6 +55,7 @@ const loadOperators = callback => {
       if (packagesErr) {
         console.error(packagesErr.message);
       }
+
       persistentStore.setOperators(normalizedOperators, callback);
     });
   });

--- a/server/store/persistentStore.js
+++ b/server/store/persistentStore.js
@@ -132,7 +132,12 @@ const normalizeOperatorRow = row => {
   return row;
 };
 
-exports.getOperator = (operatorName, callback) => {
+/**
+ * Find operator by full name (with version)
+ * @param {string} operatorName
+ * @param {Function} callback
+ */
+exports.getOperatorByName = (operatorName, callback) => {
   db.all(`SELECT * FROM ${OPERATOR_TABLE} where name = '${operatorName}'`, (err, rows) => {
     if (err) {
       console.error(err.message);
@@ -146,6 +151,32 @@ exports.getOperator = (operatorName, callback) => {
     }
     callback(normalizeOperatorRow(rows[0]));
   });
+};
+
+/**
+ * Find all operator (versions) by operator id
+ * @param {string} packageName name of the package where operator belongs
+ * @param {string} operatorName
+ * @param {Function} callback
+ */
+exports.getOperatorsByPackageName = (packageName, operatorName, callback) => {
+  db.all(
+    `SELECT * FROM ${OPERATOR_TABLE} WHERE packageName = '${packageName}' AND name = '${operatorName}'`,
+    (err, rows) => {
+      if (err) {
+        console.error(err.message);
+        callback(null, err.message);
+        return;
+      }
+
+      if (!_.size(rows)) {
+        callback(null, `No operator in package '${packageName}' found.`);
+        return;
+      }
+
+      callback(normalizeOperatorRow(rows[0]));
+    }
+  );
 };
 
 /**
@@ -170,6 +201,10 @@ exports.getOperatorsById = (operatorId, callback) => {
   });
 };
 
+/**
+ * Get all operators
+ * @param {Function} callback
+ */
 exports.getOperators = callback => {
   db.all(`SELECT * FROM ${OPERATOR_TABLE}`, (err, rows) => {
     if (err) {

--- a/server/utils/operatorUtils.js
+++ b/server/utils/operatorUtils.js
@@ -39,7 +39,7 @@ const getExampleYAML = (kind, operator) => {
   return null;
 };
 
-const addReplacedOperators = (packageChannel, currentOperator, operators) => {
+const addReplacedOperators = (operatorPackage, packageChannel, currentOperator, operators) => {
   const replacedOperatorName = _.get(currentOperator, 'replaces');
   if (!replacedOperatorName) {
     return;
@@ -48,7 +48,11 @@ const addReplacedOperators = (packageChannel, currentOperator, operators) => {
   const replacedOperator = _.find(operators, { name: replacedOperatorName });
   if (replacedOperator) {
     packageChannel.versions.push({ name: replacedOperator.name, version: replacedOperator.version });
-    addReplacedOperators(packageChannel, replacedOperator, operators);
+
+    // set operator package info
+    currentOperator.packageName = operatorPackage.packageName;
+
+    addReplacedOperators(operatorPackage, packageChannel, replacedOperator, operators);
   }
 };
 
@@ -73,7 +77,10 @@ const getPackageChannels = (operatorPackage, operators) => {
 
     packageChannel.versions = [{ name: currentOperator.name, version: currentOperator.version }];
 
-    addReplacedOperators(packageChannel, currentOperator, operators);
+    // set operator package info
+    currentOperator.packageName = operatorPackage.packageName;
+
+    addReplacedOperators(operatorPackage, packageChannel, currentOperator, operators);
     return packageChannel;
   });
 
@@ -153,6 +160,12 @@ const normalizeOperator = async operator => {
   const iconObj = _.get(spec, 'icon[0]');
   const categoriesString = _.get(annotations, 'categories');
   const packageInfo = _.get(operator, 'packageInfo', {});
+
+  // if (packageInfo.packageName) {
+  //   console.log(packageInfo.packageName, operator.metadata.name);
+  // } else {
+  //   console.error('No package name', operator.metadata.name);
+  // }
 
   let thumbBase64;
 


### PR DESCRIPTION

Using package / channel / operator name as combination to get explicit version of operator in channel as package name is only unique identifier of operator