### PR TITLE
Save operator editor state so user can continue after reload

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { withRouter } from 'react-router';
-import { store } from './redux/store';
+import store from './redux/store';
 import { reduxConstants } from './redux';
 
 import OperatorHub from './pages/operatorHub/OperatorHub';

--- a/frontend/src/components/editor/manfiestUploader/UploaderFileList.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderFileList.js
@@ -26,7 +26,9 @@ function UploaderFileList({ uploads, missingUploads, removeUpload, removeAllUplo
       {uploads.map(upload => (
         <Grid.Row className="oh-operator-editor-upload__uploads__row" key={upload.index}>
           <Grid.Col xs={6}>{upload.uploadFile}</Grid.Col>
-          <Grid.Col xs={3}>{upload.status}</Grid.Col>
+          <Grid.Col xs={3}>
+            <UploaderStatusIcon text={upload.status} status={upload.errored ? IconStatus.ERROR : IconStatus.SUCCESS} />
+          </Grid.Col>
           <Grid.Col xs={3} className="oh-operator-editor-upload__uploads__actions-col">
             <a href="#" onClick={e => removeUpload(e, upload.index)}>
               <Icon type="fa" name="trash" />
@@ -54,8 +56,8 @@ UploaderFileList.propTypes = {
       index: PropTypes.number.isRequired,
       uploadFile: PropTypes.string.isRequired,
       data: PropTypes.object,
-      uploadError: PropTypes.bool.isRequired,
-      status: PropTypes.node.isRequired
+      errored: PropTypes.bool.isRequired,
+      status: PropTypes.string.isRequired
     })
   ).isRequired,
   missingUploads: PropTypes.arrayOf(

--- a/frontend/src/components/modals/ConfirmationModal.js
+++ b/frontend/src/components/modals/ConfirmationModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Icon } from 'patternfly-react';
 
-import { store } from '../../redux/store';
+import store from '../../redux/store';
 import { reduxConstants } from '../../redux/index';
 import MessageDialog from './MessageDialog';
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { store } from './redux/store';
+import store from './redux/store';
 import App from './App';
 import './style.scss';
 

--- a/frontend/src/pages/operatorBundlePage/OperatorBundlePage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorBundlePage.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
@@ -12,8 +11,9 @@ import { operatorFieldDescriptions, operatorObjectDescriptions } from '../../uti
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import PreviewOperatorModal from '../../components/modals/PreviewOperatorModal';
 import { EDITOR_STATUS } from './bundlePageUtils';
-import { defaultOperator, validateOperator } from '../../utils/operatorUtils';
+import { validateOperator } from '../../utils/operatorUtils';
 import OperatorBundleDownloader from '../../components/editor/BundleDownloader';
+import { resetEditorOperatorAction } from '../../redux/actions/editorActions';
 
 class OperatorBundlePage extends React.Component {
   state = {
@@ -87,10 +87,7 @@ class OperatorBundlePage extends React.Component {
     const { operator, uploads, operatorPackage } = this.props;
     const { validCSV, sectionsValid } = this.state;
 
-    const isDefault = _.isEqual(operator, defaultOperator);
     const okToDownload = validCSV && sectionsValid;
-
-    const clearClasses = classNames('oh-button oh-button-secondary', { disabled: isDefault });
 
     return (
       <div className="oh-operator-editor-page__button-bar">
@@ -108,7 +105,7 @@ class OperatorBundlePage extends React.Component {
             Preview
           </button>
         </div>
-        <button className={clearClasses} disabled={isDefault} onClick={this.clearContents}>
+        <button className="oh-button oh-button-secondary" onClick={this.clearContents}>
           Clear Content
         </button>
       </div>
@@ -249,10 +246,7 @@ OperatorBundlePage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  resetEditorOperator: () =>
-    dispatch({
-      type: reduxConstants.RESET_EDITOR_OPERATOR
-    }),
+  resetEditorOperator: () => dispatch(resetEditorOperatorAction()),
   showConfirmModal: onConfirm =>
     dispatch({
       type: reduxConstants.CONFIRMATION_MODAL_SHOW,

--- a/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
@@ -2,14 +2,16 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import * as _ from 'lodash-es';
 import { Breadcrumb } from 'patternfly-react';
 
 import { helpers } from '../../common/helpers';
 import Page from '../../components/page/Page';
-import { reduxConstants } from '../../redux';
 import { operatorFieldDescriptions } from '../../utils/operatorDescriptors';
 import { EDITOR_STATUS } from './bundlePageUtils';
+import { setSectionStatusAction } from '../../redux/actions/editorActions';
+import { reduxConstants } from '../../redux/index';
 
 class OperatorEditorSubPage extends React.Component {
   state = {
@@ -246,7 +248,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_KEYWORD_SEARCH,
       keywordSearch
     }),
-  setSectionStatus: (section, status) => dispatch({ type: reduxConstants.SET_EDITOR_SECTION_STATUS, section, status }),
+  setSectionStatus: (section, status) => dispatch(setSectionStatusAction(section, status)),
   showPageErrorsMessage: () =>
     dispatch({
       type: reduxConstants.CONFIRMATION_MODAL_SHOW,

--- a/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
@@ -19,6 +19,7 @@ import {
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import DescriptionEditor from '../../components/editor/DescriptionEditor';
 import EditorSelect from '../../components/editor/EditorSelect';
+import { setSectionStatusAction } from '../../redux/actions/editorActions';
 
 const metadataDescription = `
   The metadata section contains general metadata around the name, version, and other info that aids users in the
@@ -419,12 +420,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_EDITOR_FORM_ERRORS,
       formErrors
     }),
-  setSectionStatus: status =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_SECTION_STATUS,
-      section: 'metadata',
-      status
-    })
+  setSectionStatus: status => dispatch(setSectionStatusAction('metadata', status))
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
@@ -18,6 +18,7 @@ import DescriptorsEditor, { isDescriptorEmpty } from '../../components/editor/De
 import YamlViewer from '../../components/YamlViewer';
 import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from './bundlePageUtils';
 import { getDefaultOnwedCRD } from '../../utils/operatorUtils';
+import { setSectionStatusAction } from '../../redux/actions/editorActions';
 
 const crdsField = sectionsFields['owned-crds'];
 
@@ -467,12 +468,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_EDITOR_FORM_ERRORS,
       formErrors
     }),
-  setSectionStatus: (status, section) =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_SECTION_STATUS,
-      section,
-      status
-    })
+  setSectionStatus: (status, section) => dispatch(setSectionStatusAction(section, status))
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
@@ -10,6 +10,7 @@ import { renderOperatorFormField, EDITOR_STATUS } from './bundlePageUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import { operatorPackageFieldValidators } from '../../utils/operatorDescriptors';
 import { getValueError } from '../../utils/operatorUtils';
+import { setSectionStatusAction } from '../../redux/actions/editorActions';
 
 const FIELDS = ['name', 'channel'];
 
@@ -134,12 +135,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_EDITOR_PACKAGE,
       operatorPackage
     }),
-  setSectionStatus: status =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_SECTION_STATUS,
-      section: 'package',
-      status
-    })
+  setSectionStatus: status => dispatch(setSectionStatusAction('package', status))
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorRequiredCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorRequiredCRDEditPage.js
@@ -13,6 +13,7 @@ import {
   operatorFieldValidators
 } from '../../utils/operatorDescriptors';
 import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from './bundlePageUtils';
+import { setSectionStatusAction } from '../../redux/actions/editorActions';
 
 const crdsField = sectionsFields['required-crds'];
 
@@ -242,12 +243,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_EDITOR_FORM_ERRORS,
       formErrors
     }),
-  setSectionStatus: (status, section) =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_SECTION_STATUS,
-      section,
-      status
-    })
+  setSectionStatus: (status, section) => dispatch(setSectionStatusAction(status, section))
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorYamlEditorPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorYamlEditorPage.js
@@ -10,6 +10,7 @@ import { parseYamlOperator, yamlFromOperator } from './bundlePageUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import PreviewOperatorModal from '../../components/modals/PreviewOperatorModal';
 import { defaultOperator } from '../../utils/operatorUtils';
+import { resetEditorOperatorAction } from '../../redux/actions/editorActions';
 
 class OperatorYamlEditorPage extends React.Component {
   state = {
@@ -154,10 +155,7 @@ const mapDispatchToProps = dispatch => ({
       type: reduxConstants.SET_EDITOR_OPERATOR,
       operator
     }),
-  resetEditorOperator: () =>
-    dispatch({
-      type: reduxConstants.RESET_EDITOR_OPERATOR
-    }),
+  resetEditorOperator: () => dispatch(resetEditorOperatorAction()),
   showConfirmModal: onConfirm =>
     dispatch({
       type: reduxConstants.CONFIRMATION_MODAL_SHOW,

--- a/frontend/src/redux/actions/editorActions.js
+++ b/frontend/src/redux/actions/editorActions.js
@@ -1,0 +1,16 @@
+import { reduxConstants } from '../index';
+import { clearAutosavedOperatorData } from '../../utils/operatorUtils';
+
+export const setSectionStatusAction = (section, status) => ({
+  type: reduxConstants.SET_EDITOR_SECTION_STATUS,
+  section,
+  status
+});
+
+export const resetEditorOperatorAction = () => {
+  clearAutosavedOperatorData();
+
+  return {
+    type: reduxConstants.RESET_EDITOR_OPERATOR
+  };
+};

--- a/frontend/src/redux/editorAutosave.js
+++ b/frontend/src/redux/editorAutosave.js
@@ -1,0 +1,54 @@
+import store from './store';
+import { AUTOSAVE_FIELDS, LOCAL_STORAGE_KEY } from '../utils/constants';
+
+let lastStateSnapshot = null;
+
+const autoSaveFieldsChanged = state => {
+  const changed = AUTOSAVE_FIELDS.some(field => {
+    const snapshotValue = lastStateSnapshot[field];
+    const stateFieldValue = state.editorState[field];
+
+    return snapshotValue !== stateFieldValue;
+  });
+
+  return changed;
+};
+
+const takeSnapshot = state =>
+  AUTOSAVE_FIELDS.reduce((aggregator, field) => {
+    aggregator[field] = state.editorState[field];
+
+    return aggregator;
+  }, {});
+
+const saveSnapshot = state => {
+  lastStateSnapshot = takeSnapshot(state);
+};
+
+const saveEditorData = state => {
+  let success = true;
+
+  const snapshot = takeSnapshot(state);
+
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(snapshot));
+  } catch (e) {
+    success = false;
+  }
+
+  return success;
+};
+
+const autoSaveEditor = () => {
+  const state = store.getState();
+
+  // take snapshot if not existing
+  if (lastStateSnapshot === null) {
+    saveSnapshot(state);
+  } else if (autoSaveFieldsChanged(state)) {
+    saveEditorData(state);
+    saveSnapshot(state);
+  }
+};
+
+export { autoSaveEditor };

--- a/frontend/src/redux/editorReducer.js
+++ b/frontend/src/redux/editorReducer.js
@@ -1,26 +1,40 @@
-import * as _ from 'lodash-es';
-import { reduxConstants } from './index';
-import { defaultOperator } from '../utils/operatorUtils';
+import _ from 'lodash-es';
 
-const getInitialState = () => ({
-  operator: _.cloneDeep(defaultOperator),
-  operatorPackage: {
-    name: '',
-    channel: ''
-  },
-  uploads: [],
-  formErrors: {},
-  sectionStatus: {
-    metadata: 'empty',
-    'owned-crds': 'empty',
-    'required-crds': 'empty',
-    deployments: 'empty',
-    permissions: 'empty',
-    'cluster-permissions': 'empty',
-    'install-modes': 'empty',
-    package: 'empty'
+import { reduxConstants } from './index';
+import { getAutoSavedOperatorData, defaultOperator } from '../utils/operatorUtils';
+
+const getInitialState = () => {
+  const autoSaved = getAutoSavedOperatorData();
+
+  const initialState = {
+    operator: _.cloneDeep(defaultOperator),
+    operatorPackage: {
+      name: '',
+      channel: ''
+    },
+    uploads: [],
+    formErrors: {},
+    sectionStatus: {
+      metadata: 'empty',
+      'owned-crds': 'empty',
+      'required-crds': 'empty',
+      deployments: 'empty',
+      permissions: 'empty',
+      'cluster-permissions': 'empty',
+      'install-modes': 'empty',
+      package: 'empty'
+    }
+  };
+
+  if (autoSaved) {
+    initialState.operator = autoSaved.operator;
+    initialState.operatorPackage = autoSaved.operatorPackage;
+    initialState.sectionStatus = autoSaved.sectionStatus;
+    initialState.uploads = autoSaved.uploads || [];
   }
-});
+
+  return initialState;
+};
 
 const initialState = getInitialState();
 
@@ -29,14 +43,18 @@ const editorReducer = (state = initialState, action) => {
 
   switch (action.type) {
     case reduxConstants.SET_EDITOR_SECTION_STATUS:
-      sectionStatus = _.clone(state.sectionStatus);
-      sectionStatus[action.section] = action.status;
+      sectionStatus = {
+        ...state.sectionStatus,
+        [action.section]: action.status
+      };
+
       return Object.assign({}, state, { sectionStatus });
 
     case reduxConstants.RESET_EDITOR_OPERATOR:
       return Object.assign({}, state, getInitialState());
 
     case reduxConstants.SET_EDITOR_OPERATOR:
+      // save operator on change
       return Object.assign({}, state, {
         operator: action.operator
       });

--- a/frontend/src/redux/store.js
+++ b/frontend/src/redux/store.js
@@ -4,6 +4,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
 import { createBrowserHistory } from 'history';
 import { reduxReducers } from './index';
+import { autoSaveEditor } from './editorAutosave';
 
 const history = createBrowserHistory();
 const composeEnhancer = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -17,4 +18,6 @@ const reloadReducers = () => {
   store.replaceReducer(connectRouter(history)(reduxReducers));
 };
 
-export { store as default, store, reloadReducers };
+store.subscribe(autoSaveEditor);
+
+export { store as default, reloadReducers };

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,3 +1,5 @@
 export const OPERATOR_DESCRIPTION_APPLICATION_HEADER = '## About the managed application';
 export const OPERATOR_DESCRIPTION_ABOUT_HEADER = '## About this Operator';
 export const OPERATOR_DESCRIPTION_PREREQUISITES_HEADER = '## Prerequisites for enabling this Operator';
+export const LOCAL_STORAGE_KEY = 'rh-operator-editor';
+export const AUTOSAVE_FIELDS = ['operator', 'operatorPackage', 'sectionStatus', 'uploads'];

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -3,7 +3,8 @@ import { operatorFieldValidators } from './operatorDescriptors';
 import {
   OPERATOR_DESCRIPTION_ABOUT_HEADER,
   OPERATOR_DESCRIPTION_APPLICATION_HEADER,
-  OPERATOR_DESCRIPTION_PREREQUISITES_HEADER
+  OPERATOR_DESCRIPTION_PREREQUISITES_HEADER,
+  LOCAL_STORAGE_KEY
 } from './constants';
 import { sectionsFields, mergeDescriptions } from '../pages/operatorBundlePage/bundlePageUtils';
 
@@ -259,6 +260,40 @@ const isOwnedCrdDefault = crd => _.isEqual(crd, getDefaultOnwedCRD());
 const isRequiredCrdDefault = crd => _.isEqual(crd, getDefaultRequiredCRD());
 
 /**
+ * @typedef AutoSavedData
+ * @prop {Object} AutoSavedData.sectionStatus sections status
+ * @prop {Object} AutoSavedData.operator serialized operator state
+ * @prop {Object} AutoSavedData.operatorPackage serialized operator package data
+ * @prop {Object} AutoSavedData.uploads uploaded files for operator
+ */
+
+/**
+ * Load autosaved operator and editor metadata or use default if none is saved
+ * or browser disabled local storage (e.g. some private modes)
+ * @returns {AutoSavedData}
+ */
+const getAutoSavedOperatorData = () => {
+  let savedData = null;
+
+  try {
+    savedData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
+  } catch (e) {
+    console.warn("Localstorage is disabled. Autosave won't worker.");
+  }
+
+  return savedData;
+};
+
+const clearAutosavedOperatorData = () => {
+  try {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};
+
+/**
  * @typedef PropError
  * @prop {string} PropError.key
  * @prop {string} PropError.value
@@ -497,5 +532,7 @@ export {
   validCapabilityStrings,
   validateOperator,
   getValueError,
-  getFieldValueError
+  getFieldValueError,
+  getAutoSavedOperatorData,
+  clearAutosavedOperatorData
 };


### PR DESCRIPTION
Fixed uploaded files metadata model so it can be serialized (no react nodes!)
Replaced inlined some actions with action creator so we can add side effect into action and have no duplicity
Autosaving relevant editor data into local storage
Clearing local storage when editor is cleared