### PR TITLE
Ppromp on leaving page

### DIFF
--- a/frontend/src/components/editor/manfiestUploader/ManifestUploader.js
+++ b/frontend/src/components/editor/manfiestUploader/ManifestUploader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import _ from 'lodash-es';
@@ -15,10 +16,14 @@ import {
   getMissingCrdUploads
 } from '../../../pages/operatorBundlePage/bundlePageUtils';
 import { defaultOperator, getDefaultOnwedCRD } from '../../../utils/operatorUtils';
-import { IconStatus } from './UploaderStatusIcon';
 import UploaderDropArea from './UploaderDropArea';
 import UploaderFileList from './UploaderFileList';
-import { setSectionStatusAction } from '../../../redux/actions/editorActions';
+import {
+  setSectionStatusAction,
+  updateOperatorPackageAction,
+  setUploadsAction,
+  storeEditorOperatorAction
+} from '../../../redux/actions/editorActions';
 
 const validFileTypes = ['.yaml'];
 const validFileTypesRegExp = new RegExp(`(${validFileTypes.join('|').replace(/\./g, '\\.')})$`, 'i');
@@ -398,30 +403,22 @@ ManifestUploader.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  showErrorModal: error =>
-    dispatch({
-      type: reduxConstants.CONFIRMATION_MODAL_SHOW,
-      title: 'Error Uploading File',
-      icon: <Icon type="pf" name="error-circle-o" />,
-      heading: error,
-      confirmButtonText: 'OK'
-    }),
-  markSectionForReview: sectionName => dispatch(setSectionStatusAction(sectionName, EDITOR_STATUS.pending)),
-  updateOperatorPackage: operatorPackage =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_PACKAGE,
-      operatorPackage
-    }),
-  setUploads: uploads =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_UPLOADS,
-      uploads
-    }),
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    })
+  ...bindActionCreators(
+    {
+      showErrorModal: error => ({
+        type: reduxConstants.CONFIRMATION_MODAL_SHOW,
+        title: 'Error Uploading File',
+        icon: <Icon type="pf" name="error-circle-o" />,
+        heading: error,
+        confirmButtonText: 'OK'
+      }),
+      markSectionForReview: sectionName => setSectionStatusAction(sectionName, EDITOR_STATUS.pending),
+      updateOperatorPackage: updateOperatorPackageAction,
+      setUploads: setUploadsAction,
+      storeEditorOperator: storeEditorOperatorAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorCRDsPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorCRDsPage.js
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import ListObjectEditor from '../../components/editor/ListObjectEditor';
 import { getFieldValueError } from '../../utils/operatorUtils';
 import { operatorObjectDescriptions } from '../../utils/operatorDescriptors';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const OperatorCRDsPage = ({
   operator,
@@ -85,16 +86,13 @@ OperatorCRDsPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { safeDump, safeLoad } from 'js-yaml';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import YamlViewer from '../../components/YamlViewer';
 import { sectionsFields } from './bundlePageUtils';
 import { getValueError, defaultDeployment } from '../../utils/operatorUtils';
 import { operatorFieldValidators } from '../../utils/operatorDescriptors';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const deploymentFields = sectionsFields.deployments;
 
@@ -139,16 +140,13 @@ OperatorDeploymentEditPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorDeploymentsPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorDeploymentsPage.js
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import { getFieldValueError } from '../../utils/operatorUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import ListObjectEditor from '../../components/editor/ListObjectEditor';
 import { sectionsFields } from './bundlePageUtils';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const deploymentFields = sectionsFields.deployments;
 
@@ -87,16 +88,13 @@ OperatorDeploymentsPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorInstallModesPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorInstallModesPage.js
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import { getFieldValueError } from '../../utils/operatorUtils';
 import InstallModeEditor from '../../components/editor/InstallModeEditor';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import { sectionsFields } from './bundlePageUtils';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const installModesFields = sectionsFields['install-modes'];
 
@@ -57,16 +58,13 @@ OperatorInstallModesPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import { categoryOptions, maturityOptions, operatorFieldPlaceholders } from '../../utils/operatorDescriptors';
 import CapabilityEditor from '../../components/editor/CapabilityEditor';
 import LabelsEditor from '../../components/editor/LabelsEditor';
@@ -19,7 +19,11 @@ import {
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import DescriptionEditor from '../../components/editor/DescriptionEditor';
 import EditorSelect from '../../components/editor/EditorSelect';
-import { setSectionStatusAction } from '../../redux/actions/editorActions';
+import {
+  setSectionStatusAction,
+  storeEditorFormErrorsAction,
+  storeEditorOperatorAction
+} from '../../redux/actions/editorActions';
 
 const metadataDescription = `
   The metadata section contains general metadata around the name, version, and other info that aids users in the
@@ -410,17 +414,14 @@ OperatorMetadataPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    }),
-  setSectionStatus: status => dispatch(setSectionStatusAction('metadata', status))
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction,
+      setSectionStatus: status => setSectionStatusAction('metadata', status)
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { safeDump, safeLoad } from 'js-yaml';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import ResourcesEditor from '../../components/editor/ResourcesEditor';
 import {
@@ -18,7 +18,11 @@ import DescriptorsEditor, { isDescriptorEmpty } from '../../components/editor/De
 import YamlViewer from '../../components/YamlViewer';
 import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from './bundlePageUtils';
 import { getDefaultOnwedCRD } from '../../utils/operatorUtils';
-import { setSectionStatusAction } from '../../redux/actions/editorActions';
+import {
+  setSectionStatusAction,
+  storeEditorFormErrorsAction,
+  storeEditorOperatorAction
+} from '../../redux/actions/editorActions';
 
 const crdsField = sectionsFields['owned-crds'];
 
@@ -458,17 +462,14 @@ OperatorOwnedCRDEditPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    }),
-  setSectionStatus: (status, section) => dispatch(setSectionStatusAction(section, status))
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction,
+      setSectionStatus: setSectionStatusAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import { renderOperatorFormField, EDITOR_STATUS } from './bundlePageUtils';
 
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import { operatorPackageFieldValidators } from '../../utils/operatorDescriptors';
 import { getValueError } from '../../utils/operatorUtils';
-import { setSectionStatusAction } from '../../redux/actions/editorActions';
+import { setSectionStatusAction, updateOperatorPackageAction } from '../../redux/actions/editorActions';
 
 const FIELDS = ['name', 'channel'];
 
@@ -130,12 +130,13 @@ OperatorPackagePage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperatorPackage: operatorPackage =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_PACKAGE,
-      operatorPackage
-    }),
-  setSectionStatus: status => dispatch(setSectionStatusAction('package', status))
+  ...bindActionCreators(
+    {
+      storeEditorOperatorPackage: updateOperatorPackageAction,
+      setSectionStatus: status => setSectionStatusAction('package', status)
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorPermissionsEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorPermissionsEditPage.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import { renderFormError, sectionsFields } from './bundlePageUtils';
 import {
@@ -15,6 +15,7 @@ import {
   operatorObjectDescriptions
 } from '../../utils/operatorDescriptors';
 import RulesEditor from '../../components/editor/RulesEditor';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const permissionFields = sectionsFields.permissions;
 
@@ -176,16 +177,13 @@ OperatorPermissionsEditPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorPermissionsPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorPermissionsPage.js
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import ListObjectEditor from '../../components/editor/ListObjectEditor';
 import { getFieldValueError } from '../../utils/operatorUtils';
 import { operatorObjectDescriptions } from '../../utils/operatorDescriptors';
 import { sectionsFields } from './bundlePageUtils';
+import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const permissionFields = sectionsFields.permissions;
 
@@ -93,16 +94,13 @@ OperatorPermissionsPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorRequiredCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorRequiredCRDEditPage.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { reduxConstants } from '../../redux';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import {
   operatorFieldDescriptions,
@@ -13,7 +13,11 @@ import {
   operatorFieldValidators
 } from '../../utils/operatorDescriptors';
 import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from './bundlePageUtils';
-import { setSectionStatusAction } from '../../redux/actions/editorActions';
+import {
+  setSectionStatusAction,
+  storeEditorFormErrorsAction,
+  storeEditorOperatorAction
+} from '../../redux/actions/editorActions';
 
 const crdsField = sectionsFields['required-crds'];
 
@@ -233,17 +237,14 @@ OperatorRequiredCRDEditPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  storeEditorFormErrors: formErrors =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_FORM_ERRORS,
-      formErrors
-    }),
-  setSectionStatus: (status, section) => dispatch(setSectionStatusAction(status, section))
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      storeEditorFormErrors: storeEditorFormErrorsAction,
+      setSectionStatus: setSectionStatusAction
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorYamlEditorPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorYamlEditorPage.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { helpers } from '../../common/helpers';
@@ -10,7 +11,7 @@ import { parseYamlOperator, yamlFromOperator } from './bundlePageUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import PreviewOperatorModal from '../../components/modals/PreviewOperatorModal';
 import { defaultOperator } from '../../utils/operatorUtils';
-import { resetEditorOperatorAction } from '../../redux/actions/editorActions';
+import { resetEditorOperatorAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 class OperatorYamlEditorPage extends React.Component {
   state = {
@@ -150,25 +151,24 @@ OperatorYamlEditorPage.defaultProps = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  storeEditorOperator: operator =>
-    dispatch({
-      type: reduxConstants.SET_EDITOR_OPERATOR,
-      operator
-    }),
-  resetEditorOperator: () => dispatch(resetEditorOperatorAction()),
-  showConfirmModal: onConfirm =>
-    dispatch({
-      type: reduxConstants.CONFIRMATION_MODAL_SHOW,
-      title: 'Clear Content',
-      heading: <span>Are you sure you want to clear the current content of the editor?</span>,
-      confirmButtonText: 'Clear',
-      cancelButtonText: 'Cancel',
-      onConfirm
-    }),
-  hideConfirmModal: () =>
-    dispatch({
-      type: reduxConstants.CONFIRMATION_MODAL_HIDE
-    })
+  ...bindActionCreators(
+    {
+      storeEditorOperator: storeEditorOperatorAction,
+      resetEditorOperator: resetEditorOperatorAction,
+      showConfirmModal: onConfirm => ({
+        type: reduxConstants.CONFIRMATION_MODAL_SHOW,
+        title: 'Clear Content',
+        heading: <span>Are you sure you want to clear the current content of the editor?</span>,
+        confirmButtonText: 'Clear',
+        cancelButtonText: 'Cancel',
+        onConfirm
+      }),
+      hideConfirmModal: () => ({
+        type: reduxConstants.CONFIRMATION_MODAL_HIDE
+      })
+    },
+    dispatch
+  )
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/redux/actions/editorActions.js
+++ b/frontend/src/redux/actions/editorActions.js
@@ -7,6 +7,11 @@ export const setSectionStatusAction = (section, status) => ({
   status
 });
 
+export const storeEditorOperatorAction = operator => ({
+  type: reduxConstants.SET_EDITOR_OPERATOR,
+  operator
+});
+
 export const resetEditorOperatorAction = () => {
   clearAutosavedOperatorData();
 
@@ -14,3 +19,18 @@ export const resetEditorOperatorAction = () => {
     type: reduxConstants.RESET_EDITOR_OPERATOR
   };
 };
+
+export const updateOperatorPackageAction = operatorPackage => ({
+  type: reduxConstants.SET_EDITOR_PACKAGE,
+  operatorPackage
+});
+
+export const setUploadsAction = uploads => ({
+  type: reduxConstants.SET_EDITOR_UPLOADS,
+  uploads
+});
+
+export const storeEditorFormErrorsAction = formErrors => ({
+  type: reduxConstants.SET_EDITOR_FORM_ERRORS,
+  formErrors
+});

--- a/frontend/src/redux/editorReducer.js
+++ b/frontend/src/redux/editorReducer.js
@@ -8,6 +8,7 @@ const getInitialState = () => {
 
   const initialState = {
     operator: _.cloneDeep(defaultOperator),
+    operatorModified: false,
     operatorPackage: {
       name: '',
       channel: ''
@@ -56,7 +57,8 @@ const editorReducer = (state = initialState, action) => {
     case reduxConstants.SET_EDITOR_OPERATOR:
       // save operator on change
       return Object.assign({}, state, {
-        operator: action.operator
+        operator: action.operator,
+        operatorModified: true
       });
 
     case reduxConstants.SET_EDITOR_PACKAGE:

--- a/frontend/src/redux/store.js
+++ b/frontend/src/redux/store.js
@@ -20,4 +20,12 @@ const reloadReducers = () => {
 
 store.subscribe(autoSaveEditor);
 
+window.onbeforeunload = e => {
+  const state = store.getState();
+  if (state.editorState.operatorModified) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+};
+
 export { store as default, reloadReducers };


### PR DESCRIPTION
Prompt user when leaving operatorhub.io after he has changed operator in editor
When operator is unchanged we do not disturb user as no data might be loosed

As side work refactoring of editor actions was finished and actions defined in single file using action creator pattern instead of duplicated actions everywhere