### PR TITLE
Missing default ALM example for CRD and other bugs

### DIFF
--- a/frontend/src/components/YamlViewer.js
+++ b/frontend/src/components/YamlViewer.js
@@ -111,11 +111,12 @@ class YamlViewer extends React.Component {
   };
 
   confirmClearYaml = () => {
-    const { storePreviewYaml, isPreview, hideConfirmModal } = this.props;
+    const { storePreviewYaml, isPreview, hideConfirmModal, onClear } = this.props;
 
-    this.doc.setValue('');
+    const newValue = onClear ? onClear() : '';
+    this.doc.setValue(newValue);
     if (isPreview) {
-      storePreviewYaml('', false, false);
+      storePreviewYaml(newValue, false, false);
     }
     hideConfirmModal();
     this.saveYAML();
@@ -439,6 +440,7 @@ YamlViewer.propTypes = {
   onRemove: PropTypes.func,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
+  onClear: PropTypes.func,
   error: PropTypes.node,
   storePreviewYaml: PropTypes.func,
   storeContentHeight: PropTypes.func,
@@ -462,6 +464,7 @@ YamlViewer.defaultProps = {
   onRemove: helpers.noop,
   onChange: helpers.noop,
   onBlur: helpers.noop,
+  onClear: null,
   error: null,
   storePreviewYaml: helpers.noop,
   storeContentHeight: helpers.noop,

--- a/frontend/src/components/editor/manfiestUploader/UploaderObjectList.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderObjectList.js
@@ -59,11 +59,14 @@ function UploaderObjectList({ uploads, missingUploads, removeUpload, removeAllUp
       ))}
       {missingUploads.map(missing => (
         <Grid.Row className="oh-operator-editor-upload__uploads__row" key={missing.name}>
-          <Grid.Col xs={9} title={missing.name}>
+          <Grid.Col xs={6} className="oh-operator-editor-upload__uploads__row__name" title={missing.name}>
             {missing.name}
           </Grid.Col>
+          <Grid.Col xs={3} className="oh-operator-editor-upload__uploads__row__type" title="CustomResourceDefinition">
+            CustomResourceDefinition
+          </Grid.Col>
           <Grid.Col xs={2}>
-            <UploaderStatusIcon status={IconStatus.MISSING} text="Missing CRD" />
+            <UploaderStatusIcon status={IconStatus.MISSING} text="Missing" />
           </Grid.Col>
           <Grid.Col xs={1} className="oh-operator-editor-upload__uploads__actions-col" />
         </Grid.Row>

--- a/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDsPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDsPage.js
@@ -23,6 +23,7 @@ const OperatorOwnedCRDsPage = ({ operator, history }) => {
       crdsDescription={description}
       objectPage="owned-crds"
       objectType="Owned CRD"
+      removeAlmExamples
       history={history}
     />
   );

--- a/frontend/src/styles/operator-editor-page.scss
+++ b/frontend/src/styles/operator-editor-page.scss
@@ -534,6 +534,12 @@
         margin: 0;
       }
 
+      &__subtitle{
+        font-size: 0.8em;
+        opacity: 0.8;
+        margin-left: 10px;
+      }
+
       &__actions {
         .oh-button {
           margin: 0 10px;

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -3,3 +3,4 @@ export const OPERATOR_DESCRIPTION_ABOUT_HEADER = '## About this Operator';
 export const OPERATOR_DESCRIPTION_PREREQUISITES_HEADER = '## Prerequisites for enabling this Operator';
 export const LOCAL_STORAGE_KEY = 'rh-operator-editor';
 export const AUTOSAVE_FIELDS = ['operator', 'operatorPackage', 'sectionStatus', 'uploads'];
+export const NEW_CRD_NAME = 'new-crd';

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -193,6 +193,15 @@ const defaultDeployment = {
   }
 };
 
+const getDefaultAlmExample = () => ({
+  apiVersion: '',
+  kind: '',
+  metadata: {
+    name: ''
+  },
+  spec: {}
+});
+
 const defaultOperator = {
   apiVersion: 'operators.coreos.com/v1alpha1',
   kind: 'ClusterServiceVersion',
@@ -200,16 +209,7 @@ const defaultOperator = {
     name: '',
     namespace: 'placeholder',
     annotations: {
-      'alm-examples': `[
-        {
-          "apiVersion": "",
-          "kind": "",
-          "metadata": {
-            "name": ""
-          },
-          "spec": {}
-        }
-      ]`,
+      'alm-examples': `[${JSON.stringify(getDefaultAlmExample())}]`,
       categories: '',
       certified: false,
       description: '',
@@ -258,6 +258,24 @@ const defaultOperator = {
 
 const isOwnedCrdDefault = crd => _.isEqual(crd, getDefaultOnwedCRD());
 const isRequiredCrdDefault = crd => _.isEqual(crd, getDefaultRequiredCRD());
+
+/**
+ * Convert ALM examples to objects so we can find one for current CRD
+ */
+const convertExampleYamlToObj = examples => {
+  let crdTemplates;
+  if (_.isString(examples)) {
+    try {
+      crdTemplates = JSON.parse(examples);
+    } catch (e) {
+      console.error(`Unable to convert alm-examples: ${e}`);
+      crdTemplates = [];
+    }
+  } else {
+    crdTemplates = examples;
+  }
+  return crdTemplates;
+};
 
 /**
  * @typedef AutoSavedData
@@ -524,10 +542,13 @@ const validateOperator = operator => {
 export {
   generateIdFromVersionedName,
   getDefaultDescription,
+  getDefaultAlmExample,
   normalizeOperator,
   defaultOperator,
   defaultDeployment,
+  getDefaultRequiredCRD,
   getDefaultOnwedCRD,
+  convertExampleYamlToObj,
   removeEmptyOptionalValuesFromOperator,
   validCapabilityStrings,
   validateOperator,


### PR DESCRIPTION
rho-81 fixed case when no alm example was found and example editor was empty what leads to wrong error

fixed clearing example editor should add default example
fixed removing owned crd which did not removed corresponding alm example
fixed duplicated crds created when new crd was added under circumstances
fixed inconsistencies in required crds as local state was used but not always synced with globa state
showing all crds even without name as user was able to create CRD which was not visible in CRD list but appeared under missing CRDs to upload