### PR TITLE
Rho 180 section status

### DIFF
--- a/frontend/src/components/editor/BundleDownloader.js
+++ b/frontend/src/components/editor/BundleDownloader.js
@@ -97,9 +97,6 @@ class OperatorBundleDownloader extends React.PureComponent {
       updatedSectionsStatus.package = EDITOR_STATUS.errors;
     }
 
-    // console.log(`Operator is ${operatorIsValid ? 'valid' : 'invalid'}`);
-    // console.log(`Operator package is ${packageIsValid ? 'valid' : 'invalid'}`);
-
     if (Object.keys(updatedSectionsStatus).length > 0) {
       setBatchSectionsStatus(updatedSectionsStatus);
     }

--- a/frontend/src/components/editor/ListObjectEditor.js
+++ b/frontend/src/components/editor/ListObjectEditor.js
@@ -25,7 +25,7 @@ class ListObjectEditor extends React.Component {
   editOperatorObject = operatorObject => {
     const { history, objectPage, pagePathField } = this.props;
     const transformedName = helpers.transformNameForPath(_.get(operatorObject, pagePathField));
-    history.push(`/bundle/${objectPage}/${transformedName}`);
+    history.push(`/bundle/${objectPage}/${transformedName || '[none]'}`);
   };
 
   removeOperatorObject = (event, operatorObject) => {

--- a/frontend/src/pages/operatorBundlePage/OperatorBundlePage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorBundlePage.js
@@ -32,7 +32,7 @@ class OperatorBundlePage extends React.Component {
       const status = sectionStatus[sectionName];
 
       // skip validation for sections which are not started yet
-      if (sectionStatus === EDITOR_STATUS.empty) {
+      if (status === EDITOR_STATUS.empty) {
         return;
       }
 

--- a/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
@@ -8,10 +8,14 @@ import { safeDump, safeLoad } from 'js-yaml';
 import { helpers } from '../../common/helpers';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import YamlViewer from '../../components/YamlViewer';
-import { sectionsFields } from './bundlePageUtils';
+import { sectionsFields, EDITOR_STATUS } from './bundlePageUtils';
 import { getValueError, getDefaultDeployment, isDeploymentDefault } from '../../utils/operatorUtils';
 import { operatorFieldValidators } from '../../utils/operatorDescriptors';
-import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
+import {
+  storeEditorFormErrorsAction,
+  storeEditorOperatorAction,
+  setSectionStatusAction
+} from '../../redux/actions/editorActions';
 
 const deploymentFields = sectionsFields.deployments;
 
@@ -112,6 +116,8 @@ class OperatorDeploymentEditPage extends React.Component {
   };
 
   onYamlChange = yaml => {
+    const { setSectionStatus } = this.props;
+
     /** @type {string|string[]} */
     let yamlError = '';
 
@@ -124,6 +130,8 @@ class OperatorDeploymentEditPage extends React.Component {
       yamlError = e.message;
     }
     this.setState({ yamlError });
+
+    setSectionStatus(EDITOR_STATUS.pending);
   };
 
   getDefaultOnClear = () => {
@@ -169,6 +177,7 @@ class OperatorDeploymentEditPage extends React.Component {
 OperatorDeploymentEditPage.propTypes = {
   operator: PropTypes.object,
   storeEditorOperator: PropTypes.func,
+  setSectionStatus: PropTypes.func,
   history: PropTypes.shape({
     push: PropTypes.func.isRequired
   }).isRequired,
@@ -177,14 +186,16 @@ OperatorDeploymentEditPage.propTypes = {
 
 OperatorDeploymentEditPage.defaultProps = {
   operator: {},
-  storeEditorOperator: helpers.noop
+  storeEditorOperator: helpers.noop,
+  setSectionStatus: helpers.noop
 };
 
 const mapDispatchToProps = dispatch => ({
   ...bindActionCreators(
     {
       storeEditorOperator: storeEditorOperatorAction,
-      storeEditorFormErrors: storeEditorFormErrorsAction
+      storeEditorFormErrors: storeEditorFormErrorsAction,
+      setSectionStatus: status => setSectionStatusAction('deployments', status)
     },
     dispatch
   )

--- a/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorDeploymentEditPage.js
@@ -9,58 +9,79 @@ import { helpers } from '../../common/helpers';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import YamlViewer from '../../components/YamlViewer';
 import { sectionsFields } from './bundlePageUtils';
-import { getValueError, getDefaultDeployment } from '../../utils/operatorUtils';
+import { getValueError, getDefaultDeployment, isDeploymentDefault } from '../../utils/operatorUtils';
 import { operatorFieldValidators } from '../../utils/operatorDescriptors';
 import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
 
 const deploymentFields = sectionsFields.deployments;
 
 class OperatorDeploymentEditPage extends React.Component {
+  /**
+   * @type {Object} state
+   * @prop {string} state.deploymentYaml
+   * @prop {string|string[]} state.yamlError
+   */
   state = {
-    deployment: null,
-    deploymentYaml: ''
+    deploymentYaml: '',
+    yamlError: ''
   };
 
+  name;
+
   componentDidMount() {
-    const { operator, storeEditorOperator } = this.props;
-    const name = helpers.transformPathedName(_.get(this.props.match, 'params.deployment', ''));
+    this.name = helpers.transformPathedName(_.get(this.props.match, 'params.deployment', ''));
 
-    const operatorDeployments = _.get(operator, deploymentFields, []);
-
-    let deployment = _.find(operatorDeployments, { name });
-
-    if (!deployment) {
-      deployment = getDefaultDeployment();
-
-      // override name so its obvious that its new
-      deployment.name = 'Add Deployment';
-
-      operatorDeployments.push(deployment);
-      const updatedOperator = _.cloneDeep(operator);
-      _.set(updatedOperator, deploymentFields, operatorDeployments);
-      storeEditorOperator(updatedOperator);
-    }
-
+    const deployment = this.getDeployment();
     let deploymentYaml;
-    let yamlError;
+    /** @type {string|string[]} */
+    let yamlError = '';
     try {
       deploymentYaml = safeDump(deployment);
-      yamlError = '';
+
+      // validate on first open in case we have non default deployment
+      if (!isDeploymentDefault(deployment)) {
+        yamlError = this.validateDeployment(deployment);
+      }
     } catch (e) {
       deploymentYaml = '';
       yamlError = e.message;
     }
 
-    this.setState({ deployment, deploymentYaml, yamlError });
+    this.setState({ deploymentYaml, yamlError });
   }
+
+  getDeployment = () => {
+    const { operator, storeEditorOperator } = this.props;
+    const operatorDeployments = _.get(operator, deploymentFields, []);
+
+    let deployment = _.find(operatorDeployments, { name: this.name });
+
+    if (!deployment) {
+      const updatedOperator = _.cloneDeep(operator);
+      const updatedDeployments = _.get(updatedOperator, deploymentFields, []);
+
+      deployment = getDefaultDeployment();
+
+      updatedDeployments.push(deployment);
+
+      _.set(updatedOperator, deploymentFields, updatedDeployments);
+      storeEditorOperator(updatedOperator);
+    }
+
+    return deployment;
+  };
 
   updateOperator = updatedDeployment => {
     const { operator, storeEditorOperator } = this.props;
-    const { deployment } = this.state;
 
     const updatedOperator = _.cloneDeep(operator);
     const deployments = _.get(updatedOperator, deploymentFields);
-    const deploymentIndex = _.findIndex(deployments, { name: deployment.name });
+    // use orignal name
+    const deploymentIndex = _.findIndex(deployments, { name: this.name });
+
+    // update name ref for case it changed
+    this.name = updatedDeployment.name || this.name;
+
     const updatedDeployments = [
       ...deployments.slice(0, deploymentIndex),
       updatedDeployment,
@@ -68,7 +89,6 @@ class OperatorDeploymentEditPage extends React.Component {
     ];
     _.set(updatedOperator, deploymentFields, updatedDeployments);
 
-    this.setState({ deployment: updatedDeployment });
     storeEditorOperator(updatedOperator);
   };
 
@@ -92,10 +112,11 @@ class OperatorDeploymentEditPage extends React.Component {
   };
 
   onYamlChange = yaml => {
+    /** @type {string|string[]} */
     let yamlError = '';
+
     try {
       const updatedDeployment = safeLoad(yaml);
-
       yamlError = this.validateDeployment(updatedDeployment);
 
       this.updateOperator(updatedDeployment);
@@ -103,6 +124,19 @@ class OperatorDeploymentEditPage extends React.Component {
       yamlError = e.message;
     }
     this.setState({ yamlError });
+  };
+
+  getDefaultOnClear = () => {
+    const deployment = getDefaultDeployment();
+    let deploymentYaml = '';
+
+    try {
+      deploymentYaml = safeDump(deployment);
+    } catch (e) {
+      console.warn("Can't convert default deployment to yaml!");
+    }
+
+    return deploymentYaml;
   };
 
   render() {
@@ -118,7 +152,14 @@ class OperatorDeploymentEditPage extends React.Component {
         history={history}
       >
         <div className="oh-operator-editor-deployment">
-          <YamlViewer yaml={deploymentYaml} onBlur={this.onYamlChange} editable error={yamlError} allowClear />
+          <YamlViewer
+            yaml={deploymentYaml}
+            onBlur={this.onYamlChange}
+            editable
+            error={yamlError}
+            allowClear
+            onClear={this.getDefaultOnClear}
+          />
         </div>
       </OperatorEditorSubPage>
     );

--- a/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
@@ -19,18 +19,18 @@ class OperatorEditorSubPage extends React.Component {
   };
 
   componentDidMount() {
-    const { validatePage, setSectionStatus, section } = this.props;
+    const { validatePage, setSectionStatus, section, sectionStatus } = this.props;
 
     this.updateTitleHeight();
     this.onWindowResize = helpers.debounce(this.updateTitleHeight, 100);
     window.addEventListener('resize', this.onWindowResize);
 
-    if (section) {
-      if (validatePage() === false) {
+    // do not validate pristine page
+    if (sectionStatus[section] !== EDITOR_STATUS.empty) {
+      // validate page to display errors when opened
+      if (section && validatePage() === false) {
         setSectionStatus(section, EDITOR_STATUS.errors);
-        return;
       }
-      setSectionStatus(section, EDITOR_STATUS.pending);
     }
   }
 
@@ -120,50 +120,19 @@ class OperatorEditorSubPage extends React.Component {
     </Breadcrumb>
   );
 
-  renderButtonBar() {
-    const { buttonBar, secondary, tertiary, pageErrors } = this.props;
-
-    if (buttonBar) {
-      return buttonBar;
-    }
-
-    if (secondary) {
-      const allSetClasses = classNames('oh-button oh-button-primary', { disabled: pageErrors });
-
-      return (
-        <div className="oh-operator-editor-page__button-bar">
-          <div>
-            <button className="oh-button oh-button-secondary" onClick={e => this.onEditor(e)}>
-              Back to Package your Operator
-            </button>
-          </div>
-          <div>
-            <button className={allSetClasses} disabled={pageErrors} onClick={e => this.allSet(e)}>
-              {`All set with ${this.props.title}`}
-            </button>
-          </div>
-        </div>
-      );
-    }
-
-    if (tertiary) {
-      return (
-        <div className="oh-operator-editor-page__button-bar">
-          <span />
-          <div>
-            <button className="oh-button oh-button-primary" onClick={e => this.onBack(e)}>
-              {`Back to ${this.props.lastPageTitle}`}
-            </button>
-          </div>
-        </div>
-      );
-    }
-
-    return null;
-  }
-
   render() {
-    const { header, title, field, description, children, pageId } = this.props;
+    const {
+      header,
+      title,
+      field,
+      description,
+      children,
+      pageId,
+      buttonBar,
+      secondary,
+      tertiary,
+      pageErrors
+    } = this.props;
     const { keywordSearch, headerHeight, titleHeight } = this.state;
 
     return (
@@ -180,8 +149,7 @@ class OperatorEditorSubPage extends React.Component {
         <div className="oh-operator-editor-page" id={pageId}>
           <div className="oh-operator-editor-page__title-area" ref={this.setTitleAreaRef} style={{ top: headerHeight }}>
             <div className="oh-operator-editor-page__title-area__inner">
-              {header && header}
-              {!header && (
+              {header || (
                 <React.Fragment>
                   <h1>{title}</h1>
                   {description}
@@ -193,7 +161,24 @@ class OperatorEditorSubPage extends React.Component {
           <div className="oh-operator-editor-page__page-area" style={{ marginTop: titleHeight || 0 }}>
             {children}
           </div>
-          {this.renderButtonBar()}
+          {buttonBar ||
+            (secondary && (
+              <div className="oh-operator-editor-page__button-bar">
+                <button className="oh-button oh-button-secondary" onClick={this.onEditor}>
+                  Back to Package your Operator
+                </button>
+                <button className="oh-button oh-button-primary" disabled={pageErrors} onClick={this.allSet}>
+                  {`All set with ${this.props.title}`}
+                </button>
+              </div>
+            )) ||
+            (tertiary && (
+              <div className="oh-operator-editor-page__button-bar__tertiary">
+                <button className="oh-button oh-button-primary" onClick={this.onBack}>
+                  {`Back to ${this.props.lastPageTitle}`}
+                </button>
+              </div>
+            ))}
         </div>
       </Page>
     );
@@ -220,7 +205,8 @@ OperatorEditorSubPage.propTypes = {
   }).isRequired,
   setSectionStatus: PropTypes.func,
   showPageErrorsMessage: PropTypes.func,
-  storeKeywordSearch: PropTypes.func
+  storeKeywordSearch: PropTypes.func,
+  sectionStatus: PropTypes.object
 };
 
 OperatorEditorSubPage.defaultProps = {
@@ -240,7 +226,8 @@ OperatorEditorSubPage.defaultProps = {
   children: null,
   setSectionStatus: helpers.noop,
   showPageErrorsMessage: helpers.noop,
-  storeKeywordSearch: helpers.noop
+  storeKeywordSearch: helpers.noop,
+  sectionStatus: {}
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorOwnedCRDEditPage.js
@@ -63,7 +63,7 @@ class OperatorOwnedCRDEditPage extends React.Component {
   isNewCRD = false;
 
   componentDidMount() {
-    const { operator, formErrors, storeEditorFormErrors } = this.props;
+    const { operator, formErrors, storeEditorFormErrors, sectionStatus } = this.props;
     const name = helpers.transformPathedName(_.get(this.props.match, 'params.crd', ''));
     let operatorCRDs = _.get(operator, crdsField);
 
@@ -96,11 +96,14 @@ class OperatorOwnedCRDEditPage extends React.Component {
     // used to reference CRD when name changes
     this.originalName = crd.name;
 
-    // get existing errors and revalidate CRDs fields
-    const errors = getUpdatedFormErrors(operator, formErrors, crdsField);
+    // do not update status or validate pristine page
+    if (sectionStatus !== EDITOR_STATUS.empty) {
+      // get existing errors and revalidate CRDs fields
+      const errors = getUpdatedFormErrors(operator, formErrors, crdsField);
 
-    this.updateCrdErrors(errors);
-    storeEditorFormErrors(errors);
+      this.updateCrdErrors(errors);
+      storeEditorFormErrors(errors);
+    }
 
     this.setState({ crd, crdTemplate });
 
@@ -472,7 +475,7 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = state => ({
   operator: state.editorState.operator,
   formErrors: state.editorState.formErrors,
-  sectionStatus: {}
+  sectionStatus: state.editorState.sectionStatus
 });
 
 export default connect(

--- a/frontend/src/styles/operator-editor-page.scss
+++ b/frontend/src/styles/operator-editor-page.scss
@@ -158,6 +158,10 @@
         margin-left: 0;
       }
     }
+
+    &__tertiary{
+      justify-content: flex-end;
+    }
   }
 
   &#oh-editor-landing-page{

--- a/frontend/src/utils/operatorDescriptors.js
+++ b/frontend/src/utils/operatorDescriptors.js
@@ -703,6 +703,22 @@ const operatorFieldValidators = {
               contextualValidator: deploymentSpecContextualValidator
             }
           }
+        },
+        permissions: {
+          isArray: true,
+          itemValidator: {
+            serviceAccountName: {
+              required: true
+            }
+          }
+        },
+        clusterPermissions: {
+          isArray: true,
+          itemValidator: {
+            serviceAccountName: {
+              required: true
+            }
+          }
         }
       }
     },

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -195,7 +195,7 @@ const defaultOperator = {
         clusterPermissions: [],
         deployments: [
           {
-            name: 'example-operator',
+            name: 'add-deployment',
             spec: {
               replicas: 1,
               selector: {


### PR DESCRIPTION
Fixed deployment section validation to validate immediately on opening without need to click into editor

Refactored validation of all sections so:
- landing pages for multi object sections (deployment, CRDs, permissions) validate section when opened
- Section is not marked "In review" when opened
- Section is marked in review once item modified
( This does not work for CRDs as it would require to completely rewrite those sections so they change state once item editor is opened)
- Back button does not mess section state
- Done button can be used only when there are no errors in section

Editor landing page does validate sections when opened to display status correctly when changes are done in Markedown editor!

After uploading files editor re-validates changed sections to display errors correctly