### PR TITLE
CR example files parsing

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "files.eol": "\n",
+    "javascript.referencesCodeLens.enabled": true,
+    "javascript.validate.enable": true,
+    "editor.suggest.localityBonus": true,
+    "eslint.autoFixOnSave": true,
+    "eslint.alwaysShowStatus": true,
+    "eslint.packageManager": "yarn",
+    "flow.enabled": false,
+    "flow.stopFlowOnExit": true,
+    "flow.showStatus": true
+}

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "checkJs": true,
+        "allowSyntheticDefaultImports": true,
+        "jsx": "react"
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/frontend/src/components/editor/BundleDownloader.js
+++ b/frontend/src/components/editor/BundleDownloader.js
@@ -13,13 +13,12 @@ import {
   yamlFromOperator,
   operatorNameFromOperator,
   filterValidCrdUploads,
-  EDITOR_STATUS,
-  getUpdatedFormErrors,
-  sectionsFields
+  getUpdatedFormErrors
 } from '../../pages/operatorBundlePage/bundlePageUtils';
 import { removeEmptyOptionalValuesFromOperator, validateOperatorPackage } from '../../utils/operatorUtils';
 import { reduxConstants } from '../../redux';
 import { setBatchSectionsStatusAction } from '../../redux/actions/editorActions';
+import { sectionsFields, EDITOR_STATUS } from '../../utils/constants';
 
 class OperatorBundleDownloader extends React.PureComponent {
   generateAction = null;

--- a/frontend/src/components/editor/EditorSection.js
+++ b/frontend/src/components/editor/EditorSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { Icon } from 'patternfly-react';
-import { EDITOR_STATUS } from '../../pages/operatorBundlePage/bundlePageUtils';
+import { EDITOR_STATUS } from '../../utils/constants';
 
 const EditorSection = ({ sectionStatus, title, description, sectionLocation, history }) => {
   const status = _.get(sectionStatus, sectionLocation);

--- a/frontend/src/components/editor/descriptors/Descriptor.js
+++ b/frontend/src/components/editor/descriptors/Descriptor.js
@@ -5,9 +5,9 @@ import classNames from 'classnames';
 import { Icon } from 'patternfly-react';
 import DescriptorInput from './DescriptorInput';
 import { operatorFieldPlaceholders } from '../../../utils/operatorDescriptors';
-import { sectionsFields } from '../../../pages/operatorBundlePage/bundlePageUtils';
 import { helpers } from '../../../common/helpers';
 import EditorSelect from '../EditorSelect';
+import { sectionsFields } from '../../../utils/constants';
 
 /**
  * @callback OperatorDescriptorChangeCallback

--- a/frontend/src/components/editor/descriptors/DescriptorInput.js
+++ b/frontend/src/components/editor/descriptors/DescriptorInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash-es';
 import classNames from 'classnames';
 import { operatorFieldPlaceholders } from '../../../utils/operatorDescriptors';
-import { sectionsFields } from '../../../pages/operatorBundlePage/bundlePageUtils';
+import { sectionsFields } from '../../../utils/constants';
 
 /**
  * @callback DescriptorInputOnBlurCallback

--- a/frontend/src/components/editor/manfiestUploader/UploaderTypes.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderTypes.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {'Package'|'ClusterServiceVersion'|'CustomResourceDefinition'|'Deployment'|
- * 'ServiceAccount'|'ClusterRole'| 'Role'|'ClusterRoleBinding'|'RoleBinding'|'Unknown'} ObjectType
+ * 'ServiceAccount'|'ClusterRole'| 'Role'|'ClusterRoleBinding'|'RoleBinding'|'CustomResourceExampleTemplate'|'Unknown'} ObjectType
  */
 
 /**

--- a/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
@@ -1,0 +1,186 @@
+import _ from 'lodash-es';
+
+import { generateIdFromVersionedName, getDefaultOperator, getDefaultOnwedCRD } from '../../../utils/operatorUtils';
+import { sectionsFields } from '../../../utils/constants';
+
+export const securityObjectTypes = ['ClusterRole', 'Role', 'ClusterRoleBinding', 'RoleBinding'];
+const almExampleFileNameRegExp = new RegExp('^.+_cr.yaml$');
+
+/**
+ * Derive file type from its content
+ * @param {*} content
+ * @param {string} fileName
+ * @returns {TypeAndName|null}
+ */
+export function getObjectNameAndType(content, fileName) {
+  if (almExampleFileNameRegExp.test(fileName) && content.kind) {
+    return {
+      type: 'CustomResourceExampleTemplate',
+      name: content.kind
+    };
+  } else if (content.kind && content.apiVersion && content.metadata) {
+    const type = content.kind;
+    const { name } = content.metadata;
+    const apiName = content.apiVersion.substring(0, content.apiVersion.indexOf('/'));
+
+    if (type === 'ClusterServiceVersion' && apiName === 'operators.coreos.com') {
+      return { type, name };
+    } else if (type === 'CustomResourceDefinition' && apiName === 'apiextensions.k8s.io') {
+      return { type, name };
+    } else if (type === 'Deployment' && apiName === 'apps') {
+      return { type, name };
+    } else if (type === 'ServiceAccount') {
+      return { type, name };
+    } else if (securityObjectTypes.includes(type) && apiName === 'rbac.authorization.k8s.io') {
+      return { type, name };
+    }
+
+    // package file is different with no kind and API
+  } else if (content.packageName && content.channels) {
+    return {
+      type: 'Package',
+      name: content.packageName
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Detects file upload overwriting other version of same file
+ * @param {UploadMetadata[]} uploads
+ */
+export function markReplacedObjects(uploads) {
+  // iterate over uploads backwards
+  for (let i = uploads.length - 1; i >= 0; i--) {
+    const upload = uploads[i];
+
+    if (
+      !upload.errored &&
+      (upload.type === 'ClusterServiceVersion' || upload.type === 'CustomResourceDefinition') &&
+      upload.data
+    ) {
+      const id = generateIdFromVersionedName(upload.name);
+
+      if (id) {
+        // search for CSVs or CRDs with same name (but not version) and mark them as overriden
+        // as they would be replaced by latest upload
+        uploads.forEach((otherUpload, index) => {
+          // check only older files before current index
+          if (index < i && !otherUpload.errored && otherUpload.data && otherUpload.type === upload.type) {
+            const otherId = generateIdFromVersionedName(otherUpload.name);
+
+            if (otherId === id) {
+              otherUpload.overwritten = true;
+
+              // for CSV mark overriden every previous csv as we can have only single one!
+            } else if (upload.type === otherUpload.type && otherUpload.type === 'ClusterServiceVersion') {
+              otherUpload.overwritten = true;
+            }
+          }
+        });
+      }
+    }
+  }
+
+  return uploads;
+}
+
+/**
+ * Identify if operator field was changed by upload
+ * @param {string} fieldName
+ * @param {Operator} operator
+ * @param {Operator} uploadedOperator
+ * @param {Operator} mergedOperator
+ */
+export function operatorFieldWasUpdated(fieldName, operator, uploadedOperator, mergedOperator) {
+  const defaultOperator = getDefaultOperator();
+
+  // field changed when either its value changed
+  // or uploaded operator was same as default values
+  return (
+    !_.isEqual(_.get(operator, fieldName), _.get(mergedOperator, fieldName)) ||
+    // do not consider updated if value is empty - no real change was doen
+    (!_.isEmpty(_.get(defaultOperator, fieldName)) &&
+      _.isEqual(_.get(defaultOperator, fieldName), _.get(uploadedOperator, fieldName)))
+  );
+}
+
+/**
+ * @param {string} fileName
+ * @returns {UploadMetadata}
+ */
+export const createtUpload = fileName => ({
+  id: `${Date.now()}_${Math.random().toString()}`,
+  name: '',
+  data: undefined,
+  type: 'Unknown',
+  status: '',
+  fileName,
+  errored: false,
+  overwritten: false
+});
+
+/**
+ * Creates errored upload status
+ * @param {string} fileName
+ * @param {string} errorStatus
+ */
+export function createErroredUpload(fileName, errorStatus) {
+  const upload = this.createtUpload(fileName);
+  upload.errored = true;
+  upload.status = errorStatus;
+
+  return upload;
+}
+
+export const generateDescriptorFromPath = path => ({
+  path,
+  description: _.startCase(path),
+  displayName: _.startCase(path)
+});
+
+/**
+ * Filter latest object based on defined type and namespace
+ * Used for filtering roles / role bindings / service account
+ * @param {UploadMetadata[]} uploads
+ * @param {'ClusterRole'|'Role'|'ClusterRoleBinding'|'RoleBinding'|'ServiceAccount'} type
+ * @param {string} namespace
+ */
+export function filterPermissionUploads(uploads, type, namespace) {
+  return uploads
+    .filter(up => {
+      const name = _.get(up.data, 'metadata.name');
+      return !up.errored && up.type === type && name === namespace;
+    })
+    .reverse()[0];
+}
+
+/**
+ * Add default list of resources to CRD which have them undefined
+ */
+export function addDefaultResourceStructureToCrd(crd) {
+  const resources = crd.resources && crd.resources.length > 0 ? crd.resources : getDefaultOnwedCRD().resources;
+  return {
+    ...crd,
+    resources
+  };
+}
+
+/**
+ * Apply modifications on uploaded operator as adding default resources to CRDs
+ */
+export function augmentOperator(operator, uploadedOperator) {
+  const clonedOperator = _.cloneDeep(operator);
+  const ownedCrds = _.get(clonedOperator, sectionsFields['owned-crds'], []);
+
+  _.set(clonedOperator, sectionsFields['owned-crds'], ownedCrds.map(crd => addDefaultResourceStructureToCrd(crd)));
+
+  // replace example deployments with uploaded as merge might add undesired properties!
+  const deployments = _.get(uploadedOperator, sectionsFields.deployments);
+  if (deployments) {
+    _.set(clonedOperator, sectionsFields.deployments, deployments);
+  }
+
+  return clonedOperator;
+}

--- a/frontend/src/pages/operatorBundlePage/OperatorDeploymentsPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorDeploymentsPage.js
@@ -8,13 +8,14 @@ import { helpers } from '../../common/helpers';
 import { getFieldValueError, containsErrors } from '../../utils/operatorUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import ListObjectEditor from '../../components/editor/ListObjectEditor';
-import { getUpdatedFormErrors, EDITOR_STATUS, sectionsFields } from './bundlePageUtils';
+import { getUpdatedFormErrors } from './bundlePageUtils';
 
 import {
   storeEditorFormErrorsAction,
   storeEditorOperatorAction,
   setSectionStatusAction
 } from '../../redux/actions/editorActions';
+import { sectionsFields, EDITOR_STATUS } from '../../utils/constants';
 
 const deploymentFields = sectionsFields.deployments;
 

--- a/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorEditorSubPage.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { Breadcrumb } from 'patternfly-react';
@@ -8,9 +7,9 @@ import { Breadcrumb } from 'patternfly-react';
 import { helpers } from '../../common/helpers';
 import Page from '../../components/page/Page';
 import { operatorFieldDescriptions } from '../../utils/operatorDescriptors';
-import { EDITOR_STATUS } from './bundlePageUtils';
 import { setSectionStatusAction } from '../../redux/actions/editorActions';
 import { reduxConstants } from '../../redux/index';
+import { EDITOR_STATUS } from '../../utils/constants';
 
 class OperatorEditorSubPage extends React.Component {
   state = {

--- a/frontend/src/pages/operatorBundlePage/OperatorInstallModesPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorInstallModesPage.js
@@ -8,8 +8,8 @@ import { helpers } from '../../common/helpers';
 import { getFieldValueError } from '../../utils/operatorUtils';
 import InstallModeEditor from '../../components/editor/InstallModeEditor';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
-import { sectionsFields } from './bundlePageUtils';
 import { storeEditorFormErrorsAction, storeEditorOperatorAction } from '../../redux/actions/editorActions';
+import { sectionsFields } from '../../utils/constants';
 
 const installModesFields = sectionsFields['install-modes'];
 

--- a/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorMetadataPage.js
@@ -9,7 +9,7 @@ import { categoryOptions, maturityOptions, operatorFieldPlaceholders } from '../
 import CapabilityEditor from '../../components/editor/CapabilityEditor';
 import LabelsEditor from '../../components/editor/LabelsEditor';
 import ImageEditor from '../../components/editor/ImageEditor';
-import { getUpdatedFormErrors, EDITOR_STATUS, sectionsFields } from './bundlePageUtils';
+import { getUpdatedFormErrors } from './bundlePageUtils';
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import DescriptionEditor from '../../components/editor/DescriptionEditor';
 import EditorSelect from '../../components/editor/EditorSelect';
@@ -22,6 +22,7 @@ import OperatorTextArea from '../../components/editor/forms/OperatorTextArea';
 import OperatorInput from '../../components/editor/forms/OperatorInput';
 import OperatorInputWrapper from '../../components/editor/forms/OperatorInputWrapper';
 import { containsErrors } from '../../utils/operatorUtils';
+import { EDITOR_STATUS, sectionsFields } from '../../utils/constants';
 
 const metadataDescription = `
   The metadata section contains general metadata around the name, version, and other info that aids users in the

--- a/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
+++ b/frontend/src/pages/operatorBundlePage/OperatorPackagePage.js
@@ -5,12 +5,12 @@ import { connect } from 'react-redux';
 import _ from 'lodash-es';
 
 import { helpers } from '../../common/helpers';
-import { EDITOR_STATUS } from './bundlePageUtils';
 
 import OperatorEditorSubPage from './OperatorEditorSubPage';
 import { validateOperatorPackageField, validateOperatorPackage } from '../../utils/operatorUtils';
 import { setSectionStatusAction, updateOperatorPackageAction } from '../../redux/actions/editorActions';
 import OperatorInput from '../../components/editor/forms/OperatorInput';
+import { EDITOR_STATUS } from '../../utils/constants';
 
 class OperatorPackagePage extends React.Component {
   originalStatus = EDITOR_STATUS.empty;

--- a/frontend/src/pages/operatorBundlePage/bundlePageUtils.js
+++ b/frontend/src/pages/operatorBundlePage/bundlePageUtils.js
@@ -6,44 +6,9 @@ import { getFieldValueError, getDefaultDescription } from '../../utils/operatorU
 import {
   OPERATOR_DESCRIPTION_ABOUT_HEADER,
   OPERATOR_DESCRIPTION_PREREQUISITES_HEADER,
-  NEW_CRD_NAME
+  NEW_CRD_NAME,
+  sectionsFields
 } from '../../utils/constants';
-
-const EDITOR_STATUS = {
-  empty: 'empty',
-  pending: 'pending',
-  complete: 'complete',
-  errors: 'errors'
-};
-
-const sectionsFields = {
-  metadata: [
-    'spec.displayName',
-    'metadata.annotations.description',
-    'spec.maturity',
-    'spec.version',
-    'spec.replaces',
-    'spec.minKubeVersion',
-    'spec.description.aboutApplication',
-    'spec.description.aboutOperator',
-    'spec.description.prerequisites',
-    'metadata.annotations.capabilities',
-    'spec.labels',
-    'spec.selector.matchLabels',
-    'metadata.annotations.categories',
-    'spec.keywords',
-    'spec.icon',
-    'spec.links',
-    'spec.provider.name',
-    'spec.maintainers'
-  ],
-  'owned-crds': 'spec.customresourcedefinitions.owned',
-  'required-crds': 'spec.customresourcedefinitions.required',
-  deployments: 'spec.install.spec.deployments',
-  permissions: 'spec.install.spec.permissions',
-  'cluster-permissions': 'spec.install.spec.clusterPermissions',
-  'install-modes': 'spec.installModes'
-};
 
 /**
  *
@@ -234,9 +199,7 @@ const getMissingCrdUploads = (uploads, operator) => {
 };
 
 export {
-  sectionsFields,
   renderFormError,
-  EDITOR_STATUS,
   getUpdatedFormErrors,
   mergeDescriptions,
   operatorNameFromOperator,

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorCRDsPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorCRDsPage.js
@@ -14,7 +14,8 @@ import {
   storeEditorOperatorAction,
   setSectionStatusAction
 } from '../../../redux/actions/editorActions';
-import { getUpdatedFormErrors, EDITOR_STATUS, sectionsFields } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
+import { EDITOR_STATUS, sectionsFields } from '../../../utils/constants';
 
 class OperatorCRDsPage extends React.Component {
   componentDidMount() {

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDEditPage.js
@@ -11,7 +11,7 @@ import ResourcesEditor from '../../../components/editor/ResourcesEditor';
 import { operatorFieldDescriptions } from '../../../utils/operatorDescriptors';
 import DescriptorsEditor from '../../../components/editor/descriptors/DescriptorsEditor';
 import YamlViewer from '../../../components/YamlViewer';
-import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
 import {
   getDefaultOnwedCRD,
   getDefaultAlmExample,
@@ -25,7 +25,7 @@ import {
   storeEditorFormErrorsAction,
   storeEditorOperatorAction
 } from '../../../redux/actions/editorActions';
-import { NEW_CRD_NAME, SPEC_CAPABILITIES, STATUS_CAPABILITIES } from '../../../utils/constants';
+import { NEW_CRD_NAME, SPEC_CAPABILITIES, STATUS_CAPABILITIES, EDITOR_STATUS } from '../../../utils/constants';
 
 import OperatorTextAreaUncontrolled from '../../../components/editor/forms/OperatorTextAreaUncontrolled';
 import OperatorInputUncontrolled from '../../../components/editor/forms/OperatorInputUncontrolled';

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDsPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { ExternalLink } from '../../../components/ExternalLink';
 import OperatorCRDsPage from './OperatorCRDsPage';
-import { sectionsFields } from '../bundlePageUtils';
+import { sectionsFields } from '../../../utils/constants';
 
 const OperatorOwnedCRDsPage = ({ operator, history }) => {
   const description = (

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorRequiredCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorRequiredCRDEditPage.js
@@ -6,14 +6,14 @@ import * as _ from 'lodash-es';
 
 import { helpers } from '../../../common/helpers';
 import OperatorEditorSubPage from '../OperatorEditorSubPage';
-import { EDITOR_STATUS, getUpdatedFormErrors, sectionsFields } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
 import {
   setSectionStatusAction,
   storeEditorFormErrorsAction,
   storeEditorOperatorAction
 } from '../../../redux/actions/editorActions';
 import { getDefaultRequiredCRD } from '../../../utils/operatorUtils';
-import { NEW_CRD_NAME } from '../../../utils/constants';
+import { NEW_CRD_NAME, sectionsFields } from '../../../utils/constants';
 import OperatorInputUncontrolled from '../../../components/editor/forms/OperatorInputUncontrolled';
 import OperatorTextAreaUncontrolled from '../../../components/editor/forms/OperatorTextAreaUncontrolled';
 import { operatorFieldDescriptions } from '../../../utils/operatorDescriptors';

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorRequiredCRDsPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorRequiredCRDsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { ExternalLink } from '../../../components/ExternalLink';
 import OperatorCRDsPage from './OperatorCRDsPage';
-import { sectionsFields } from '../bundlePageUtils';
+import { sectionsFields } from '../../../utils/constants';
 
 const OperatorRequiredCRDsPage = ({ operator, history }) => {
   const description = (

--- a/frontend/src/pages/operatorBundlePage/deployments/OperatorBundlePage.js
+++ b/frontend/src/pages/operatorBundlePage/deployments/OperatorBundlePage.js
@@ -13,7 +13,8 @@ import PreviewOperatorModal from '../../../components/modals/PreviewOperatorModa
 import OperatorBundleDownloader from '../../../components/editor/BundleDownloader';
 import { resetEditorOperatorAction, setBatchSectionsStatusAction } from '../../../redux/actions/editorActions';
 import { removeEmptyOptionalValuesFromOperator } from '../../../utils/operatorUtils';
-import { sectionsFields, EDITOR_STATUS, getUpdatedFormErrors } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
+import { sectionsFields, EDITOR_STATUS } from '../../../utils/constants';
 
 class OperatorBundlePage extends React.Component {
   state = {

--- a/frontend/src/pages/operatorBundlePage/deployments/OperatorDeploymentEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/deployments/OperatorDeploymentEditPage.js
@@ -8,7 +8,6 @@ import { safeDump, safeLoad } from 'js-yaml';
 import { helpers } from '../../../common/helpers';
 import OperatorEditorSubPage from '../OperatorEditorSubPage';
 import YamlViewer from '../../../components/YamlViewer';
-import { sectionsFields, EDITOR_STATUS } from '../bundlePageUtils';
 import { getValueError, getDefaultDeployment, isDeploymentDefault } from '../../../utils/operatorUtils';
 import { operatorFieldValidators } from '../../../utils/operatorDescriptors';
 import {
@@ -16,6 +15,7 @@ import {
   storeEditorOperatorAction,
   setSectionStatusAction
 } from '../../../redux/actions/editorActions';
+import { sectionsFields } from '../../../utils/constants';
 
 const deploymentFields = sectionsFields.deployments;
 

--- a/frontend/src/pages/operatorBundlePage/permissions/OperatorClusterPermissionsEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/permissions/OperatorClusterPermissionsEditPage.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import OperatorPermissionsEditPage from './OperatorPermissionsEditPage';
-import { sectionsFields } from '../bundlePageUtils';
+import { sectionsFields } from '../../../utils/constants';
 
 const permissionFields = sectionsFields['cluster-permissions'];
 

--- a/frontend/src/pages/operatorBundlePage/permissions/OperatorClusterPermissionsPage.js
+++ b/frontend/src/pages/operatorBundlePage/permissions/OperatorClusterPermissionsPage.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import OperatorPermissionsPage from './OperatorPermissionsPage';
-import { sectionsFields } from '../bundlePageUtils';
+import { sectionsFields } from '../../../utils/constants';
 
 const permissionFields = sectionsFields['cluster-permissions'];
 

--- a/frontend/src/pages/operatorBundlePage/permissions/OperatorPermissionsEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/permissions/OperatorPermissionsEditPage.js
@@ -6,7 +6,7 @@ import * as _ from 'lodash-es';
 
 import { helpers } from '../../../common/helpers';
 import OperatorEditorSubPage from '../OperatorEditorSubPage';
-import { sectionsFields, EDITOR_STATUS, getUpdatedFormErrors } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
 import { operatorObjectDescriptions, operatorFieldDescriptions } from '../../../utils/operatorDescriptors';
 import RulesEditor from '../../../components/editor/RulesEditor';
 import {
@@ -15,6 +15,7 @@ import {
   setSectionStatusAction
 } from '../../../redux/actions/editorActions';
 import OperatorInputUncontrolled from '../../../components/editor/forms/OperatorInputUncontrolled';
+import { sectionsFields, EDITOR_STATUS } from '../../../utils/constants';
 
 const permissionFields = sectionsFields.permissions;
 const descriptions = _.get(operatorFieldDescriptions, permissionFields);

--- a/frontend/src/pages/operatorBundlePage/permissions/OperatorPermissionsPage.js
+++ b/frontend/src/pages/operatorBundlePage/permissions/OperatorPermissionsPage.js
@@ -9,12 +9,13 @@ import OperatorEditorSubPage from '../OperatorEditorSubPage';
 import ListObjectEditor from '../../../components/editor/ListObjectEditor';
 import { getFieldValueError, containsErrors } from '../../../utils/operatorUtils';
 import { operatorObjectDescriptions } from '../../../utils/operatorDescriptors';
-import { sectionsFields, getUpdatedFormErrors, EDITOR_STATUS } from '../bundlePageUtils';
+import { getUpdatedFormErrors } from '../bundlePageUtils';
 import {
   storeEditorFormErrorsAction,
   storeEditorOperatorAction,
   setSectionStatusAction
 } from '../../../redux/actions/editorActions';
+import { sectionsFields, EDITOR_STATUS } from '../../../utils/constants';
 
 const permissionFields = sectionsFields.permissions;
 

--- a/frontend/src/redux/actions/editorActions.js
+++ b/frontend/src/redux/actions/editorActions.js
@@ -1,12 +1,21 @@
 import { reduxConstants } from '../index';
 import { clearAutosavedOperatorData } from '../../utils/operatorUtils';
 
+/**
+ * Update status of single section
+ * @param {EditorSectionNames} section
+ * @param {EDITOR_STATUS} status
+ */
 export const setSectionStatusAction = (section, status) => ({
   type: reduxConstants.SET_EDITOR_SECTION_STATUS,
   section,
   status
 });
 
+/**
+ * Update status of multiple sections at once
+ * @param {Record<EditorSectionNames, EDITOR_STATUS>} status
+ */
 export const setBatchSectionsStatusAction = status => ({
   type: reduxConstants.SET_EDITOR_ALL_SECTIONS_STATUS,
   status
@@ -25,11 +34,19 @@ export const resetEditorOperatorAction = () => {
   };
 };
 
+/**
+ * Updates operator package
+ * @param {OperatorPackage} operatorPackage
+ */
 export const updateOperatorPackageAction = operatorPackage => ({
   type: reduxConstants.SET_EDITOR_PACKAGE,
   operatorPackage
 });
 
+/**
+ * Update uploads list
+ * @param {UploadMetadata} uploads
+ */
 export const setUploadsAction = uploads => ({
   type: reduxConstants.SET_EDITOR_UPLOADS,
   uploads

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -40,3 +40,39 @@ export const STATUS_CAPABILITIES = [
   'urn:alm:descriptor:io.kubernetes.phase:reason',
   'urn:alm:descriptor:io.kubernetes:'
 ];
+
+export const EDITOR_STATUS = {
+  empty: 'empty',
+  pending: 'pending',
+  complete: 'complete',
+  errors: 'errors'
+};
+
+export const sectionsFields = {
+  metadata: [
+    'spec.displayName',
+    'metadata.annotations.description',
+    'spec.maturity',
+    'spec.version',
+    'spec.replaces',
+    'spec.minKubeVersion',
+    'spec.description.aboutApplication',
+    'spec.description.aboutOperator',
+    'spec.description.prerequisites',
+    'metadata.annotations.capabilities',
+    'spec.labels',
+    'spec.selector.matchLabels',
+    'metadata.annotations.categories',
+    'spec.keywords',
+    'spec.icon',
+    'spec.links',
+    'spec.provider.name',
+    'spec.maintainers'
+  ],
+  'owned-crds': 'spec.customresourcedefinitions.owned',
+  'required-crds': 'spec.customresourcedefinitions.required',
+  deployments: 'spec.install.spec.deployments',
+  permissions: 'spec.install.spec.permissions',
+  'cluster-permissions': 'spec.install.spec.clusterPermissions',
+  'install-modes': 'spec.installModes'
+};

--- a/frontend/src/utils/editorTypes.js
+++ b/frontend/src/utils/editorTypes.js
@@ -1,0 +1,11 @@
+/**
+ * @typedef {'metadata'|'owned-crds'|'required-crds'|'deployments'|'permissions'|'cluster-permissions'|'install-modes'|'package'} EditorSectionNames
+ */
+
+/**
+ * @typedef {object} EDITOR_STATUS
+ * @prop {'empty'} empty
+ * @prop {'pending'} pending
+ * @prop {'complete'} complete
+ * @prop {'errors'} errors
+ */

--- a/frontend/src/utils/operatorTypes.js
+++ b/frontend/src/utils/operatorTypes.js
@@ -144,3 +144,9 @@
  * @prop {OperatorMetadata} metadata
  * @prop {OperatorSpec} spec
  */
+
+/**
+ * @typedef OperatorPackage
+ * @prop {string} name
+ * @prop {string} channel
+ */

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -4,9 +4,10 @@ import {
   OPERATOR_DESCRIPTION_ABOUT_HEADER,
   OPERATOR_DESCRIPTION_APPLICATION_HEADER,
   OPERATOR_DESCRIPTION_PREREQUISITES_HEADER,
-  LOCAL_STORAGE_KEY
+  LOCAL_STORAGE_KEY,
+  sectionsFields
 } from './constants';
-import { sectionsFields, mergeDescriptions } from '../pages/operatorBundlePage/bundlePageUtils';
+import { mergeDescriptions } from '../pages/operatorBundlePage/bundlePageUtils';
 
 /**
  * Convert version format without dashes
@@ -318,10 +319,7 @@ export function getDefaultCrdDescriptor() {
 
 /** @param {Operator} operator */
 export const isDefaultOperator = operator => _.isEqual(operator, defaultOperator);
-export const isOwnedCrdDefault = crd => {
-  console.log(crd, defaultOnwedCrdRef);
-  return _.isEqual(crd, defaultOnwedCrdRef);
-};
+export const isOwnedCrdDefault = crd => _.isEqual(crd, defaultOnwedCrdRef);
 export const isRequiredCrdDefault = crd => _.isEqual(crd, getDefaultRequiredCRD());
 export const isDeploymentDefault = deployment => _.isEqual(deployment, defaultDeploymentRef);
 export const isAlmExampleDefault = almExample => _.isEqual(almExample, getDefaultAlmExample());
@@ -591,11 +589,6 @@ export const removeEmptyOptionalValuesFromOperator = operator => {
   const ownedCRDs = _.get(clonedOperator, sectionsFields['owned-crds'], []).filter(crd => !isOwnedCrdDefault(crd));
   _.set(clonedOperator, sectionsFields['owned-crds'], ownedCRDs);
 
-  const requiredCRDs = _.get(clonedOperator, sectionsFields['required-crds'], []).filter(
-    crd => !isRequiredCrdDefault(crd)
-  );
-  _.set(clonedOperator, sectionsFields['required-crds'], requiredCRDs);
-
   return clonedOperator;
 };
 
@@ -628,7 +621,7 @@ export const validateOperator = operator => {
 
 /**
  * Validates operator package field
- * @param {*} value
+ * @param {string} value
  * @param {string} fieldName
  */
 export const validateOperatorPackageField = (value, fieldName) =>
@@ -636,7 +629,7 @@ export const validateOperatorPackageField = (value, fieldName) =>
 
 /**
  * Validatates operator package
- * @param {*} operatorPackage
+ * @param {OperatorPackage} operatorPackage
  */
 export const validateOperatorPackage = operatorPackage => {
   const FIELDS = ['name', 'channel'];


### PR DESCRIPTION
parsed CR example files and populated ALM examples
refactored Manifest uploader to separate utility functions into utils file

refactored code to add sections status and fields static validation (in VS Code)