### PR TITLE
smart operator objects merging on upload

### DIFF
--- a/frontend/src/utils/operatorTypes.js
+++ b/frontend/src/utils/operatorTypes.js
@@ -119,7 +119,7 @@
  * @prop {object} selector
  * @prop {Record<string, string>} selector.matchLabels
  * @prop {OperatorLink[]} links
- * @prop {OperatorIcon} icon
+ * @prop {OperatorIcon[]} icon
  * @prop {object} customresourcedefinitions
  * @prop {OperatorOwnedCrd[]} customresourcedefinitions.owned
  * @prop {OperatorCrd[]} customresourcedefinitions.required

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -104,10 +104,14 @@ export const normalizeOperator = operator => {
   const packageInfo = _.get(operator, 'packageInfo', {});
 
   const description = _.get(spec, 'description');
+  // fallback to short description
   let longDescription = annotations.description;
 
+  // replace with proper long description if available
   if (typeof description === 'object') {
     longDescription = mergeDescriptions(operator);
+  } else if (description !== '') {
+    longDescription = description;
   }
 
   return {


### PR DESCRIPTION
rho-317 when uploaded operator is not merge by plain strategy, but defined obejct lists are merged using unique strategy per object type

object arrays are merged using defined object property value as object identifier to link object pairs for merge