### PR TITLE
crd descriptor reordering issues

### DIFF
--- a/frontend/src/components/editor/ListObjectEditor.js
+++ b/frontend/src/components/editor/ListObjectEditor.js
@@ -23,7 +23,7 @@ class ListObjectEditor extends React.Component {
 
   editOperatorObject = (operatorObject, index) => {
     const { history, objectPage, pagePathField } = this.props;
-    const transformedName = helpers.transformNameForPath(_.get(operatorObject, pagePathField));
+    const transformedName = helpers.transformNameForPath(_.get(operatorObject, pagePathField, ''));
     history.push(`/bundle/${objectPage}/edit/${index}/${transformedName}`);
   };
 

--- a/frontend/src/components/editor/descriptors/DescriptorsEditor.js
+++ b/frontend/src/components/editor/descriptors/DescriptorsEditor.js
@@ -40,18 +40,38 @@ class DescriptorsEditor extends React.PureComponent {
   componentDidMount() {
     const { descriptors } = this.props;
 
-    descriptors.forEach((nextDescriptor, index) => {
-      if (!isCrdDescriptorDefault(nextDescriptor)) {
-        this.makeFieldDirty('displayName', index);
-        this.makeFieldDirty('description', index);
-        this.makeFieldDirty('path', index);
-        this.makeFieldDirty('x-descriptors', index);
-      }
+    descriptors.forEach((nextDescriptor, index, array) => {
+      (!isCrdDescriptorDefault(nextDescriptor) || array.length > 1) && this.makeAllFieldsDirty(index);
     });
   }
 
+  /**
+   * Set field as dirty to validate it
+   * @param {string} field
+   * @param {number} index
+   */
   makeFieldDirty = (field, index) => {
     _.set(this.dirtyDescriptors, [index, field], true);
+  };
+
+  /**
+   * Set all fields of descriptor dirty
+   * @param {number} index
+   */
+  makeAllFieldsDirty = index => {
+    this.makeFieldDirty('displayName', index);
+    this.makeFieldDirty('description', index);
+    this.makeFieldDirty('path', index);
+    this.makeFieldDirty('x-descriptors', index);
+  };
+
+  /**
+   * Set all descriptors dirty
+   */
+  setAllAsDirty = () => {
+    const { descriptors } = this.props;
+
+    descriptors.forEach((nextDescriptor, index) => this.makeAllFieldsDirty(index));
   };
 
   /**
@@ -142,6 +162,8 @@ class DescriptorsEditor extends React.PureComponent {
       }
 
       this.ordering = false;
+      // after ordering mark every descriptor dirty so errors are properly shown
+      this.setAllAsDirty();
       onUpdate(updatedDescriptors);
     }
   };
@@ -180,6 +202,8 @@ class DescriptorsEditor extends React.PureComponent {
       expanded
     } = this.props;
 
+    console.log('Rerendered editor');
+
     return (
       <ExpandCollapse textCollapsed={`Show ${title}`} textExpanded={`Hide ${title}`} expanded={expanded}>
         <div className="oh-operator-editor__descriptor-editor">
@@ -191,7 +215,7 @@ class DescriptorsEditor extends React.PureComponent {
 
               return (
                 <Descriptor
-                  key={descriptor.path}
+                  key={descriptor.id}
                   index={index}
                   descriptor={descriptor}
                   descriptorOptions={descriptorOptions}

--- a/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
@@ -8,7 +8,7 @@ import {
   isDeploymentDefault,
   isAlmExampleDefault
 } from '../../../utils/operatorUtils';
-import { sectionsFields } from '../../../utils/constants';
+import { addIdToDescriptor } from '../../../pages/operatorBundlePage/bundlePageUtils';
 
 export const securityObjectTypes = ['ClusterRole', 'Role', 'ClusterRoleBinding', 'RoleBinding'];
 const almExampleFileNameRegExp = new RegExp('^.+_cr.yaml$');
@@ -146,13 +146,17 @@ export function createErroredUpload(fileName, errorStatus) {
  * @param {string} path
  * @returns {OperatorCrdDescriptor}
  */
-export const generateDescriptorFromPath = path => ({
-  path,
-  description: _.startCase(path),
-  displayName: _.startCase(path),
-  // @ts-ignore
-  'x-descriptors': []
-});
+export const generateDescriptorFromPath = path => {
+  const descriptor = {
+    path,
+    description: _.startCase(path),
+    displayName: _.startCase(path),
+    // @ts-ignore
+    'x-descriptors': []
+  };
+
+  return addIdToDescriptor(descriptor);
+};
 
 /**
  * Filter latest object based on defined type and namespace

--- a/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDEditPage.js
+++ b/frontend/src/pages/operatorBundlePage/crds/OperatorOwnedCRDEditPage.js
@@ -283,25 +283,6 @@ class OperatorOwnedCRDEditPage extends React.Component {
     return operator;
   };
 
-  /**
-   * CRD editor populates CRD with empty samples of descriptors so they appear in form
-   * However they can't leak outside of local state as they break validation
-   * and malform CSV yaml with empty values
-   * Therefore we need to clean them up
-   */
-  cleanEmptySampleFields = crd => {
-    const cleanedCrd = _.cloneDeep(crd);
-
-    if (cleanedCrd.specDescriptors) {
-      cleanedCrd.specDescriptors = cleanedCrd.specDescriptors.filter(desc => !isCrdDescriptorDefault(desc));
-    }
-    if (cleanedCrd.statusDescriptors) {
-      cleanedCrd.statusDescriptors = cleanedCrd.statusDescriptors.filter(desc => !isCrdDescriptorDefault(desc));
-    }
-
-    return cleanedCrd;
-  };
-
   updatePagePathOnNameChange = name => {
     const { location, history, isNew } = this.props;
 
@@ -391,7 +372,7 @@ class OperatorOwnedCRDEditPage extends React.Component {
     if (statusDescriptors.length === 0) {
       statusDescriptors = [getDefaultCrdDescriptor()];
     }
-
+    console.log('CRD editor');
     return (
       <OperatorEditorSubPage
         title="Edit Owned CRD"

--- a/frontend/src/utils/operatorTypes.js
+++ b/frontend/src/utils/operatorTypes.js
@@ -64,6 +64,7 @@
 
 /**
  * @typedef OperatorCrdDescriptor
+ * @prop {string} id
  * @prop {string} displayName
  * @prop {string} description
  * @prop {string} path

--- a/frontend/src/utils/operatorUtils.js
+++ b/frontend/src/utils/operatorUtils.js
@@ -344,7 +344,7 @@ export function getDefaultDeployment() {
  */
 export function getDefaultCrdDescriptor() {
   // @ts-ignore
-  return { displayName: '', description: '', path: '', 'x-descriptors': [] };
+  return { id: Date.now().toString(), displayName: '', description: '', path: '', 'x-descriptors': [] };
 }
 
 /** @param {Operator} operator */
@@ -353,7 +353,13 @@ export const isOwnedCrdDefault = crd => _.isEqual(crd, defaultOnwedCrdRef);
 export const isRequiredCrdDefault = crd => _.isEqual(crd, getDefaultRequiredCRD());
 export const isDeploymentDefault = deployment => _.isEqual(deployment, defaultDeploymentRef);
 export const isAlmExampleDefault = almExample => _.isEqual(almExample, getDefaultAlmExample());
-export const isCrdDescriptorDefault = descriptor => _.isEqual(descriptor, getDefaultCrdDescriptor());
+export const isCrdDescriptorDefault = descriptor => {
+  const defaultDescriptor = getDefaultCrdDescriptor();
+
+  return ['displayName', 'description', 'path', 'x-descriptors'].every(prop =>
+    _.isEqual(descriptor[prop], defaultDescriptor[prop])
+  );
+};
 
 /**
  * Convert ALM examples to objects so we can find one for current CRD


### PR DESCRIPTION
rho-316 reorderng descriptors without path or with same path leads to breaking UI

yaml parser configured to not use references, but inline object