### PR TITLE
recover from missing object in multi document yaml

### DIFF
--- a/frontend/src/components/editor/manfiestUploader/ManifestUploader.js
+++ b/frontend/src/components/editor/manfiestUploader/ManifestUploader.js
@@ -89,12 +89,15 @@ class ManifestUploader extends React.Component {
       return [utils.createErroredUpload(fileName, 'Parsing Errors')];
     }
 
-    const uploads = parsedObjects.map(object => {
-      const upload = utils.createtUpload(fileName);
-      upload.data = object;
+    // remove empty sections and fix mallformed files
+    const uploads = parsedObjects
+      .filter(object => object !== null)
+      .map(object => {
+        const upload = utils.createtUpload(fileName);
+        upload.data = object;
 
-      return this.processUploadedObject(upload);
-    });
+        return this.processUploadedObject(upload);
+      });
 
     return uploads;
   };


### PR DESCRIPTION
rho-329 recover from corrupted multi document yaml which contains invalid objects (e.g. emty line)