### PR TITLE
Bash is required to run this script, not sh

### DIFF
--- a/server/scripts/update-operators.sh
+++ b/server/scripts/update-operators.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 pushd ./data/
 


### PR DESCRIPTION
The use of popd and pushd in this update-operators.sh script necessitates the use of bash not whatever is symlinked to sh (in my case dash). Those commands are not a part of simpler shells.

When run under an unsupported shell, multiple errors like the following will appear with the frontend build `npm run-script build`:
`./scripts/update-operators.sh: 3: ./scripts/update-operators.sh: pushd: not found`
This will consequently break `npm start`.
`Error: ENOENT: no such file or directory, scandir './data/community-operators/upstream-community-operators'`