### PR TITLE
failing upload in special cases

### DIFF
--- a/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
+++ b/frontend/src/components/editor/manfiestUploader/UploaderUtils.js
@@ -202,13 +202,20 @@ export function addDefaultResourceStructureToCrd(crd) {
 export function mergeArrayOfObjectsByKey(initialValues, updatedValues, keyProperty, customMerger) {
   const map = new Map();
 
+  // recover from case when values are not an array - e.g. malformed data
+  if (!Array.isArray(updatedValues)) {
+    return initialValues;
+  } else if (!Array.isArray(initialValues)) {
+    return updatedValues;
+  }
+
   // fill map with first object values
-  initialValues.forEach(element => {
+  (initialValues || []).forEach(element => {
     map.set(element[keyProperty], element);
   });
 
   // merge second object into map by key value
-  updatedValues.forEach(element => {
+  (updatedValues || []).forEach(element => {
     const key = element[keyProperty];
     let merged = element;
 


### PR DESCRIPTION
fixed fail in uploading operator if it contained null or no value instead of array for special properties (permissions, crds, etc.)