### PR TITLE
Rendering Update path for skips and skip range

### DIFF
--- a/frontend/src/components/packageEditor/channelsEditor/VersionUpdatePath.tsx
+++ b/frontend/src/components/packageEditor/channelsEditor/VersionUpdatePath.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { PackageEditorUpdatePath } from '../../../utils/packageEditorTypes';
+
+const ROW_HEIGHT = 56;
+const WIDTH = 30;
+const DIAMETER = 8;
+
+
+export interface UpdatePathProps {
+    index: number
+    distance: number
+    sortingDirection: 'asc' | 'desc',
+}
+
+const UpdatePath: React.FC<UpdatePathProps> = ({ index, distance, sortingDirection }) => {
+
+    const rotatation = sortingDirection === 'desc' ? 'rotate(90deg)' : 'rotate(-90deg)';
+    const width = distance * ROW_HEIGHT;
+    const widthPx = width + 'px';
+    const leftPx = (WIDTH * index) + 'px';    
+
+    return (
+        <div className="oh-package-channels-editor__update-graph__wrapper"
+            style={{ width: widthPx, left: leftPx, transform: rotatation }}>
+            <div className="oh-package-channels-editor__update-graph__start">&nbsp;</div>
+            <div
+                className="oh-package-channels-editor__update-graph__line"
+                style={{ width: widthPx }}
+            >&nbsp;</div>
+            <div
+                className="oh-package-channels-editor__update-graph__end"
+                style={{ left: (width - DIAMETER) + 'px' }}
+            >&nbsp;</div>
+        </div>
+    );
+}
+
+export default UpdatePath;

--- a/frontend/src/components/packageEditor/modals/EditUpdateGraphModal.tsx
+++ b/frontend/src/components/packageEditor/modals/EditUpdateGraphModal.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { Modal } from 'patternfly-react';
+
+import { noop } from '../../../common/helpers';
+import OperatorSelect from '../../editor/forms/OperatorSelect';
+
+
+type FieldNames = 'replaces';
+
+export interface UploadPackageFromGithubModalProps {
+
+  onClose: () => void
+}
+
+interface UploadPackageFromGithubModalState {
+  replaces: string,
+  validFields: Record<FieldNames, boolean>
+  formErrors: Record<FieldNames, string | null>  
+}
+
+class UploadPackageFromGithubModal extends React.PureComponent<UploadPackageFromGithubModalProps, UploadPackageFromGithubModalState> {
+
+
+  state: UploadPackageFromGithubModalState = {
+    replaces: '',
+   
+    validFields: {  
+        replaces: true
+    },
+    formErrors: {
+        replaces: null
+    }    
+  };
+
+  descriptions: Record<FieldNames, string> = {
+    replaces: 'Select the name of the CSV from a previous Operator Version that will be replaced by this Operator Version'
+  }
+
+  updateField = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    // @ts-ignore
+    this.setState({ [name]: value });
+  }
+
+  updateSelectField = (name: string, value: string[]) => {
+      console.log(name, value);
+
+      // @ts-ignore
+    this.setState({ [name]: value });
+  }
+
+  validators = {
+    replaces: (value: string) => {
+      return null;
+    }    
+  }
+
+
+  commitField = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+   
+    this.validateField(name, value);
+  }
+
+  commitSelectField = (name: string) => {
+      const value = this.state[name];
+
+      this.validateField(name, value)
+  }
+
+  validateField = (name: string, value: string) => {
+    const { formErrors, validFields } = this.state;
+
+    const error = this.validators[name](value);
+
+    this.setState({
+      formErrors: {
+        ...formErrors,
+        [name]: error
+      },
+      validFields: {
+        ...validFields,
+        [name]: typeof error !== 'string'
+      }
+    });
+
+    return error;
+  }
+
+  
+//   onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+
+//     if ((event.which === 13 || event.keyCode === 13)) {
+//         event.preventDefault();
+//         const { name, value } = event.target as HTMLInputElement;
+
+//         const validationResult = this.commitField(event as any);
+
+//         if (validationResult === null) {
+//           const {validFields} = this.state;
+
+//           const allValid = Object.values(validFields).every(field => field);
+
+//           allValid && this.upload();
+//         }
+//     }
+// };
+
+ 
+
+
+  render() {
+    const { onClose } = this.props;
+    const { replaces, formErrors, validFields } = this.state;
+
+    const allValid = Object.values(validFields).every(field => field);
+
+    return (
+      <Modal show onHide={onClose} bsSize="lg" className="oh-yaml-upload-modal right-side-modal-pf oh-operator-editor-page">
+        <Modal.Header>
+          <Modal.CloseButton onClick={onClose} />
+          <Modal.Title>Edit Update Graph</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+               
+          {
+            <form className="oh-operator-editor-form">
+              <OperatorSelect
+                title="Replaces (optional)"
+                descriptions={this.descriptions}
+                field="replaces"
+                formErrors={formErrors}
+                key="replaces"
+                values={[]}
+                options={[]}
+                isMulti
+                updateOperator={this.updateSelectField}
+                commitField={this.commitSelectField}
+              />               
+              {/* <OperatorInputWrapper
+                title="Operator package path"
+                descriptions={this.descriptions}
+                field="path"
+                formErrors={formErrors}
+                key="path"
+              >
+                <input
+                  className="form-control"
+                  name="path"
+                  type="text"
+                  onFocus={this.closeNoResultsWarning}
+                  onChange={this.updateField}
+                  onBlur={this.commitField}
+                  onKeyDown={this.onKeyDown}
+                  placeholder="e.g. upstream-community-operators/etcd"
+                  value={path}
+                />
+              </OperatorInputWrapper>
+              <OperatorInputWrapper
+                title="Branch"
+                descriptions={this.descriptions}
+                field="branch"
+                formErrors={formErrors}
+                key="branch"
+              >
+                <input
+                  className="form-control"
+                  name="branch"
+                  type="text"
+                  onFocus={this.closeNoResultsWarning}
+                  onChange={this.updateField}
+                  onBlur={this.commitField}
+                  onKeyDown={this.onKeyDown}
+                  placeholder="e.g. master"
+                  value={branch}
+                />
+              </OperatorInputWrapper> */}
+            </form>
+          }          
+        </Modal.Body>
+        <Modal.Footer>
+          <button className="oh-button oh-button-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="oh-button oh-button-primary" onClick={noop} disabled={true}>
+            Save
+          </button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+
+
+export default UploadPackageFromGithubModal;

--- a/frontend/src/components/uploader/package/PackageUploader.tsx
+++ b/frontend/src/components/uploader/package/PackageUploader.tsx
@@ -278,14 +278,16 @@ class OperatorPackageUploader extends React.PureComponent<OperatorPackageUploade
 
                 // deduplicate versions!
                 const versionsAddedBySkips = new Set<string>();
+                let oldestSkippedVersion: string = '';
 
                 if (skipRange) {
-                    const skippedByRange: string[] = [];
+                    //const skippedByRange: string[] = [];
 
                     versionsList.forEach(version => {
                         if (satisfies(version, skipRange)) {
-                            skippedByRange.push(version);
+                            //skippedByRange.push(version);
                             versionsAddedBySkips.add(version);
+                            oldestSkippedVersion = version;
                         }
                     });
                 }
@@ -301,7 +303,16 @@ class OperatorPackageUploader extends React.PureComponent<OperatorPackageUploade
                 }
 
                 channel.versions.push(...versionsAddedBySkips.values());
-                csvEntry = operatorVersions.find(operatorVersion => operatorVersion.objectName === replacedVersion);
+
+                if (replacedVersion) {
+                    csvEntry = operatorVersions.find(operatorVersion => operatorVersion.objectName === replacedVersion);
+
+                } else if (oldestSkippedVersion) {
+                    // ensure, that loop continue if no replaces exists by picking the older version
+                    csvEntry = operatorVersions.find(operatorVersion => operatorVersion.version === oldestSkippedVersion);
+                } else {
+                    csvEntry = undefined;
+                }
             }
             channel.versions
         });

--- a/frontend/src/styles/package-editor.scss
+++ b/frontend/src/styles/package-editor.scss
@@ -221,8 +221,7 @@
     height: 100%;
 
     &__wrapper {
-      position: relative;
-      float: left;
+      position: absolute;
       width: 56px;
       height: 30px;
       transform: rotate(90deg);

--- a/frontend/src/utils/operatorTypes.ts
+++ b/frontend/src/utils/operatorTypes.ts
@@ -142,6 +142,7 @@ export type OperatorSpec = {
     version: string
     replaces: string
     skips: string[]
+    'olm.skipRange'?: string
     minKubeVersion: string
     keywords: string[]
     maintainers: OperatorMaintainer[]

--- a/frontend/src/utils/packageEditorTypes.tsx
+++ b/frontend/src/utils/packageEditorTypes.tsx
@@ -48,3 +48,11 @@ export type PacakgeEditorChannel = {
     currentVersion: string,
     currentVersionFullName: string
 }
+
+export type PackageEditorUpdatePath = {
+    id: string
+    index: number
+    target: string
+    source: string
+    distance: number
+}


### PR DESCRIPTION
 rho-524 refined update path rendering to omit paths inside skip range or between skip and its dependency

fixed parsing so versions which are precedensors of oldest version in skip range are not lost