### PR TITLE
Fix OLM installation info

### DIFF
--- a/frontend/src/pages/documentation/HowToInstallOperators.tsx
+++ b/frontend/src/pages/documentation/HowToInstallOperators.tsx
@@ -45,6 +45,9 @@ const HowToInstallOperators: React.FC<HowToInstallOperatorsPageProps> = ({ histo
           </p>
           <p className="oh-documentation-page__code_snippet">
             <code>
+              kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml
+            </code>
+            <code>
               kubectl create -f
               https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
             </code>


### PR DESCRIPTION
olm.yaml is not enough to install OLM.
See more, please: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#manual-installation

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>