### PR TITLE
update the hardcoded fallback version of OLM to 0.14.1

### DIFF
--- a/frontend/src/redux/operatorsReducer.ts
+++ b/frontend/src/redux/operatorsReducer.ts
@@ -22,7 +22,7 @@ const initialState: OperatorsReducersState = {
   fulfilled: false,
   operators: [],
   operator: {} as any,
-  olmVersion: '0.11.0',
+  olmVersion: '0.14.1',
   olmVersionUpdated: false
 };
 


### PR DESCRIPTION
Sometimes the client-side requests to github fail, causing
the instructions to suggest using OLM 0.11. This fails in
latest OpenShift and kube. Update the hardcode to the currently
released OLM.

Fixes: #289