### PR TITLE
Fix link to contributing-a-pr

### DIFF
--- a/frontend/src/utils/documentationLinks.ts
+++ b/frontend/src/utils/documentationLinks.ts
@@ -1,7 +1,7 @@
 export const operatorsFramework = 'https://github.com/operator-framework';
 export const operatorsRepo = `${operatorsFramework}/community-operators`;
 export const contributions = `${operatorsRepo}/tree/master/upstream-community-operators`;
-export const operatorsRepoBeforePR = `${operatorsRepo}#before-submitting-a-pr`;
+export const operatorsRepoBeforePR = `${operatorsRepo}/blob/master/docs/contributing-via-pr.md`;
 export const operatorsRepoRequirements = `${operatorsRepo}#know-what-to-contribute`;
 export const operatorSdk = `${operatorsFramework}/operator-sdk`;
 export const operatorCourier = `${operatorsFramework}/operator-courier`;


### PR DESCRIPTION
Note that there are a few other links on this page that are likely wrong also, as they build off of the `operatorsRepo` const, and all of the docs over there have moved under a docs directory.  However, I'm not sure where the others are supposed to go.

Related PR: https://github.com/operator-framework/community-operators/pull/3108